### PR TITLE
[1.x] Adds `uses` interface support

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Arr;
 use InvalidArgumentException;
 use Livewire\Form;
 use Livewire\Volt\Exceptions\PlaceholderAlreadyDefinedException;
+use Livewire\Volt\Exceptions\TraitOrInterfaceNotFound;
 use Livewire\Volt\Exceptions\WithAlreadyDefinedException;
 use Livewire\Volt\Methods\ActionMethod;
 use Livewire\Volt\Methods\ComputedMethod;
@@ -15,7 +16,7 @@ use Livewire\Volt\Methods\JsMethod;
 use Livewire\Volt\Methods\ProtectedMethod;
 use Livewire\Volt\Options\RuleOptions;
 use Livewire\Volt\Options\StateOptions;
-use Livewire\Volt\Options\TraitOptions;
+use Livewire\Volt\Options\UsesOptions;
 
 /**
  * Define the component's state.
@@ -268,28 +269,36 @@ function rules(mixed ...$rules): RuleOptions
 /**
  * Indicate that the component supports file uploads.
  */
-function usesFileUploads(): TraitOptions
+function usesFileUploads(): UsesOptions
 {
-    return (new TraitOptions)->usesFileUploads();
+    return (new UsesOptions)->usesFileUploads();
 }
 
 /**
  * Indicate that the component supports pagination.
  */
-function usesPagination(string $view = null, string $theme = null): TraitOptions
+function usesPagination(string $view = null, string $theme = null): UsesOptions
 {
-    return (new TraitOptions)->usesPagination($view, $theme);
+    return (new UsesOptions)->usesPagination($view, $theme);
 }
 
 /**
- * Indicate that the component should use the given trait.
+ * Indicate that the component should use the given trait or interface.
  */
-function uses(array|string $name): TraitOptions
+function uses(array|string $name): UsesOptions
 {
-    CompileContext::instance()->traits = array_values(array_unique(array_merge(
-        CompileContext::instance()->traits,
+    $uses = Arr::wrap($name);
+
+    foreach ($uses as $use) {
+        if (! trait_exists($use) && ! interface_exists($use)) {
+            throw new TraitOrInterfaceNotFound($use);
+        }
+    }
+
+    CompileContext::instance()->uses = array_values(array_unique(array_merge(
+        CompileContext::instance()->uses,
         Arr::wrap($name),
     )));
 
-    return new TraitOptions;
+    return new UsesOptions;
 }

--- a/src/CompileContext.php
+++ b/src/CompileContext.php
@@ -26,7 +26,7 @@ class CompileContext
         public array $validationAttributes,
         public ?string $paginationView,
         public ?string $paginationTheme,
-        public array $traits,
+        public array $uses,
         public ?Closure $viewData,
         public ?Closure $placeholder,
 
@@ -68,9 +68,9 @@ class CompileContext
             validationAttributes: [],
             paginationView: null,
             paginationTheme: null,
-            placeholder: null,
-            traits: [],
+            uses: [],
             viewData: null,
+            placeholder: null,
 
             // Hooks...
             boot: null,

--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -44,6 +44,10 @@ class Compiler
             return (new $compiler)->compile($context);
         })->flatten()->values()->implode("\n");
 
+        $interfaces = collect((new Compilers\Interfaces)->compile($context))->whenNotEmpty(function ($interfaces) {
+            return ' implements '.collect($interfaces)->implode(', ');
+        }, fn () => '');
+
         return str(<<<PHP
             <?php
 
@@ -52,7 +56,7 @@ class Compiler
             use Livewire\Volt\Contracts\Compiled;
             use Livewire\Volt\Component;
 
-            return new class extends Component
+            return new class extends Component$interfaces
             {
                 public static CompileContext \$__context;
 

--- a/src/Compilers/Interfaces.php
+++ b/src/Compilers/Interfaces.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Livewire\Volt\Compilers;
+
+use Livewire\Volt\CompileContext;
+use Livewire\Volt\Contracts\Compiler;
+
+class Interfaces implements Compiler
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function compile(CompileContext $context): array
+    {
+        return collect($context->uses)
+            ->filter(fn (string $interface) => interface_exists($interface))
+            ->values()->all();
+    }
+}

--- a/src/Compilers/ProtectedMethods.php
+++ b/src/Compilers/ProtectedMethods.php
@@ -54,13 +54,15 @@ class ProtectedMethods implements Compiler
                 $attributes = Reflection::toAttributesSignature($reflection->attributes);
                 $signature = Reflection::toMethodSignatureFromClosure($methodName, $reflection->closure);
 
+                $return = str_ends_with($signature, 'void') ? '' : 'return ';
+
                 return <<<PHP
                     $attributes
                     protected $signature
                     {
                         \$arguments = [static::\$__context, \$this, func_get_args()];
 
-                        return (new Actions\CallMethod('$methodName'))->execute(...\$arguments);
+                        $return(new Actions\CallMethod('$methodName'))->execute(...\$arguments);
                     }
 
                 PHP;

--- a/src/Compilers/PublicMethods.php
+++ b/src/Compilers/PublicMethods.php
@@ -42,12 +42,14 @@ class PublicMethods implements Compiler
                 $attributes = Reflection::toAttributesSignature($reflection->attributes);
                 $signature = Reflection::toMethodSignatureFromClosure($methodName, $reflection->closure);
 
+                $return = str_ends_with($signature, 'void') ? '' : 'return ';
+
                 $code = <<<PHP
                     public $signature
                     {
                         \$arguments = [static::\$__context, \$this, func_get_args()];
 
-                        return (new Actions\CallMethod('$methodName'))->execute(...\$arguments);
+                        $return(new Actions\CallMethod('$methodName'))->execute(...\$arguments);
                     }
 
                 PHP;

--- a/src/Compilers/Traits.php
+++ b/src/Compilers/Traits.php
@@ -5,7 +5,6 @@ namespace Livewire\Volt\Compilers;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Livewire\Volt\CompileContext;
 use Livewire\Volt\Contracts\Compiler;
-use Livewire\Volt\Exceptions\TraitNotFound;
 
 class Traits implements Compiler
 {
@@ -14,9 +13,9 @@ class Traits implements Compiler
      */
     public function compile(CompileContext $context): array
     {
-        return collect($context->traits)
+        return collect($context->uses)
             ->prepend(AuthorizesRequests::class)
-            ->each(fn (string $trait) => trait_exists($trait) || throw new TraitNotFound($trait))
+            ->filter(fn (string $trait) => trait_exists($trait))
             ->map(fn (string $trait) => <<<PHP
                 use {$trait};
 

--- a/src/ComponentFactory.php
+++ b/src/ComponentFactory.php
@@ -29,7 +29,7 @@ class ComponentFactory
 
         foreach ($this->mountedDirectories->paths() as $mountedPath) {
             if (str_starts_with($path, $mountedPath->path)) {
-                $context->traits = array_merge($context->traits, $mountedPath->uses);
+                $context->uses = array_merge($context->uses, $mountedPath->uses);
             }
         }
 

--- a/src/Exceptions/TraitOrInterfaceNotFound.php
+++ b/src/Exceptions/TraitOrInterfaceNotFound.php
@@ -4,13 +4,13 @@ namespace Livewire\Volt\Exceptions;
 
 use InvalidArgumentException;
 
-class TraitNotFound extends InvalidArgumentException
+class TraitOrInterfaceNotFound extends InvalidArgumentException
 {
     /**
      * Create a new exception instance.
      */
     public function __construct(string $name)
     {
-        parent::__construct("Trait [$name] not found.");
+        parent::__construct("Trait or interface [$name] not found.");
     }
 }

--- a/src/Options/UsesOptions.php
+++ b/src/Options/UsesOptions.php
@@ -7,7 +7,7 @@ use function Livewire\Volt\uses;
 use Livewire\WithFileUploads;
 use Livewire\WithPagination;
 
-class TraitOptions
+class UsesOptions
 {
     /**
      * Indicate that the component should be compiled with file upload support.

--- a/tests/.pest/snapshots/Feature/ComponentTest/generated_code_with_data_set__dataset__component_with_external_interfaces_blade_php______tests_Feature_resources_view___de_php__.snap
+++ b/tests/.pest/snapshots/Feature/ComponentTest/generated_code_with_data_set__dataset__component_with_external_interfaces_blade_php______tests_Feature_resources_view___de_php__.snap
@@ -1,0 +1,37 @@
+<?php
+
+use Livewire\Volt\Actions;
+use Livewire\Volt\CompileContext;
+use Livewire\Volt\Contracts\Compiled;
+use Livewire\Volt\Component;
+
+return new class extends Component implements Tests\Fixtures\IncrementInterface
+{
+    public static CompileContext $__context;
+
+    use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+
+    use Tests\Fixtures\IncrementTrait;
+
+    public function mount()
+    {
+        (new Actions\InitializeState)->execute(static::$__context, $this, get_defined_vars());
+
+        (new Actions\CallHook('mount'))->execute(static::$__context, $this, get_defined_vars());
+    }
+
+    public function alsoIncrement(): void
+    {
+        $arguments = [static::$__context, $this, func_get_args()];
+
+        (new Actions\CallMethod('alsoIncrement'))->execute(...$arguments);
+    }
+
+    public function alsoIncrementButReturnInt(): int
+    {
+        $arguments = [static::$__context, $this, func_get_args()];
+
+        return (new Actions\CallMethod('alsoIncrementButReturnInt'))->execute(...$arguments);
+    }
+
+};

--- a/tests/Feature/Compiler/UsesTest.php
+++ b/tests/Feature/Compiler/UsesTest.php
@@ -3,9 +3,10 @@
 use Livewire\Volt\CompileContext;
 use Livewire\Volt\Compiler;
 use Livewire\Volt\Compilers\Traits;
-use Livewire\Volt\Exceptions\TraitNotFound;
+use Livewire\Volt\Exceptions\TraitOrInterfaceNotFound;
 use function Livewire\Volt\uses;
 use Livewire\WithFileUploads;
+use Tests\Fixtures\IncrementInterface;
 
 it('may not be defined', function () {
     $code = Compiler::contextToString(CompileContext::instance());
@@ -14,20 +15,22 @@ it('may not be defined', function () {
 });
 
 it('may be defined', function () {
-    uses(WithFileUploads::class);
+    uses([WithFileUploads::class, IncrementInterface::class]);
 
     $code = Compiler::contextToString(CompileContext::instance());
 
-    expect($code)->toContain(<<<'PHP'
+    expect($code)
+        ->toContain('implements Tests\Fixtures\IncrementInterface')
+        ->toContain(<<<'PHP'
         use Livewire\WithFileUploads;
     PHP
-    );
+        );
 });
 
-it('may not be defined if trait does not exist', function () {
+it('may not be defined if trait or interface does not exist', function () {
     $context = CompileContext::instance();
 
     uses('MissingTrait');
 
     (new Traits)->compile($context);
-})->throws(TraitNotFound::class, 'Trait [MissingTrait] not found.');
+})->throws(TraitOrInterfaceNotFound::class, 'Trait or interface [MissingTrait] not found.');

--- a/tests/Feature/CompilerContext/UsesFileUploadsTest.php
+++ b/tests/Feature/CompilerContext/UsesFileUploadsTest.php
@@ -7,7 +7,7 @@ use Livewire\WithFileUploads;
 it('is not used by default', function () {
     $context = CompileContext::instance();
 
-    expect($context->traits)->not->toContain(WithFileUploads::class);
+    expect($context->uses)->not->toContain(WithFileUploads::class);
 });
 
 it('may be used', function () {
@@ -15,5 +15,5 @@ it('may be used', function () {
 
     usesFileUploads();
 
-    expect($context->traits)->toContain(WithFileUploads::class);
+    expect($context->uses)->toContain(WithFileUploads::class);
 });

--- a/tests/Feature/CompilerContext/UsesPaginationTest.php
+++ b/tests/Feature/CompilerContext/UsesPaginationTest.php
@@ -7,7 +7,7 @@ use Livewire\WithPagination;
 it('is not used by default', function () {
     $context = CompileContext::instance();
 
-    expect($context->traits)->not->toContain(WithPagination::class);
+    expect($context->uses)->not->toContain(WithPagination::class);
 });
 
 it('may be used', function () {
@@ -15,7 +15,7 @@ it('may be used', function () {
 
     usesPagination();
 
-    expect($context->traits)->toContain(WithPagination::class)
+    expect($context->uses)->toContain(WithPagination::class)
         ->and($context->paginationView)->toBeNull()
         ->and($context->paginationTheme)->toBeNull();
 });

--- a/tests/Feature/CompilerContext/UsesTest.php
+++ b/tests/Feature/CompilerContext/UsesTest.php
@@ -3,17 +3,20 @@
 use Livewire\Volt\CompileContext;
 use function Livewire\Volt\uses;
 use Livewire\WithFileUploads;
+use Tests\Fixtures\IncrementInterface;
 
 it('is not used by default', function () {
     $context = CompileContext::instance();
 
-    expect($context->traits)->not->toContain(WithFileUploads::class);
+    expect($context->uses)->not->toContain(WithFileUploads::class);
 });
 
 it('may be used', function () {
     $context = CompileContext::instance();
 
     uses(WithFileUploads::class);
+    uses(IncrementInterface::class);
 
-    expect($context->traits)->toContain(WithFileUploads::class);
+    expect($context->uses)->toContain(WithFileUploads::class)
+        ->toContain(IncrementInterface::class);
 });

--- a/tests/Feature/ComponentTest.php
+++ b/tests/Feature/ComponentTest.php
@@ -420,6 +420,15 @@ it('caches components using their compiled view paths', function () {
         });
 });
 
+it('may use external interfaces', function () {
+    Livewire::test('component-with-external-interfaces')
+        ->assertSet('counter', 0)
+        ->call('increment')
+        ->call('alsoIncrement')
+        ->call('alsoIncrementButReturnInt')
+        ->assertSet('counter', 3);
+});
+
 it('may use external traits', function () {
     Livewire::test('component-with-external-traits')
         ->assertSet('counter', 0)

--- a/tests/Feature/resources/views/livewire/component-with-external-interfaces.blade.php
+++ b/tests/Feature/resources/views/livewire/component-with-external-interfaces.blade.php
@@ -1,0 +1,28 @@
+<?php
+
+use function Livewire\Volt\{state, uses};
+use Tests\Fixtures\IncrementInterface;
+
+uses([IncrementInterface::class, \Tests\Fixtures\IncrementTrait::class]);
+
+$alsoIncrement = function (): void {
+    $this->counter++;
+};
+
+$alsoIncrementButReturnInt = fn (): int => $this->counter++;
+
+?>
+
+<div>
+    Counter: {{ $counter }}
+    <br/>
+    <button wire:click="increment">
+        Increment Counter
+    </button>
+    <button wire:click="alsoIncrement">
+        Increment Counter
+    </button>
+    <button wire:click="alsoIncrementButReturnInt">
+        Increment Counter
+    </button>
+</div>

--- a/tests/Fixtures/IncrementInterface.php
+++ b/tests/Fixtures/IncrementInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Tests\Fixtures;
+
+interface IncrementInterface
+{
+    public function increment();
+
+    public function alsoIncrement(): void;
+
+    public function alsoIncrementButReturnInt(): int;
+}


### PR DESCRIPTION
This pull request closes https://github.com/livewire/volt/issues/10, and it allows to specify that the given component implements an given interface. Example:

```php
<?php

use Filament\Tables\Concerns\InteractsWithTable;
use Filament\Tables\Contracts\HasTable;
use Filament\Tables\Table;
use function Livewire\Volt\uses;

uses([HasTable::class, InteractsWithTable::class]); ?>

$table = fn(Table $table): Table => $table
    ->query(Product::query())
    ->columns([
        TextColumn::make('name'),
    ])
    ->filters([
        // ...
    ]); ?>

<div>
    ...
```