### PR TITLE
[1.x] Add example to `make:volt` prompt

### DIFF
--- a/src/Console/MakeCommand.php
+++ b/src/Console/MakeCommand.php
@@ -4,6 +4,7 @@ namespace Livewire\Volt\Console;
 
 use Illuminate\Console\Concerns\CreatesMatchingTest;
 use Illuminate\Console\GeneratorCommand;
+use Illuminate\Foundation\Application;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Str;
 use Livewire\Volt\Volt;
@@ -170,6 +171,20 @@ class MakeCommand extends GeneratorCommand
     {
         return [
             ['force', 'f', InputOption::VALUE_NONE, 'Create the Volt component even if the component already exists'],
+        ];
+    }
+
+    /**
+     * Prompt for missing input arguments using the returned questions.
+     *
+     * @return array
+     */
+    protected function promptForMissingArgumentsUsing()
+    {
+        return [
+            'name' => version_compare(Application::VERSION, '10.17.0', '>=')
+                ? ['What should the Volt component be named?', 'E.g. counter']
+                : 'What should the Volt component be named?',
         ];
     }
 }


### PR DESCRIPTION
This PR updates the `make:volt` command to include an example when prompting for the missing "name" argument:

![image](https://github.com/livewire/volt/assets/4977161/8c97d346-bbb6-4e30-9427-046587f0978c)

The goal of these placeholders is typically to prevent a trip to the docs for those that want to use conventional naming. In this case, the example was taken straight from the documentation and tells the user that a lower-case name is typical.

The placeholder feature is only supported on Laravel 10.17 or later, where Laravel Prompts is included. Previous versions that use Symfony's prompts will continue to work without seeing the placeholder.