### PR TITLE
[1.x] Improves pages using fragments without directive

### DIFF
--- a/src/Exceptions/VoltDirectiveMissingException.php
+++ b/src/Exceptions/VoltDirectiveMissingException.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Livewire\Volt\Exceptions;
+
+use RuntimeException;
+
+class VoltDirectiveMissingException extends RuntimeException
+{
+    /**
+     * Create a new exception instance.
+     */
+    public function __construct(string $bladePath)
+    {
+        parent::__construct(
+            'The [@volt] directive is required when using Volt anonymous components in Folio pages, and is missing from ['.$bladePath.'].',
+        );
+    }
+}


### PR DESCRIPTION
This pull request improves the user experience when people are trying to use Folio's pages combined with Volt's anonymous components. In the example below, is the before:

```php
<?php

use Livewire\Volt\Component;

new class extends Component {
    public $count = 2;

    public function increment()
    {
        $this->count--;
    }
} ?>

<x-app-layout>
    <div style="text-align: center">
        <button wire:click="increment">+</button>
        <h1>{{ $count }}</h1>  // <---- ERROR EXCEPTION : Undefined variable $count 
    </div>
</x-app-layout>
```

After:
<img width="1423" alt="Screenshot 2023-08-03 at 01 46 29" src="https://github.com/livewire/volt/assets/5457236/82138816-09b1-4b20-8dd8-a68fbacdb687">
