### PR TITLE
[1.x] Adds assertSeeVolt assertion

### DIFF
--- a/src/Volt.php
+++ b/src/Volt.php
@@ -5,6 +5,7 @@ namespace Livewire\Volt;
 use Illuminate\Support\Facades\Facade;
 
 /**
+ * @method static void ensureViewsAreCached()
  * @method static void mount(array|string $paths = [], array|string $uses = [])
  * @method static array paths()
  * @method static \Livewire\Features\SupportTesting\Testable test(string $name, array $params = [])

--- a/src/VoltManager.php
+++ b/src/VoltManager.php
@@ -62,17 +62,25 @@ class VoltManager
      */
     public function test(string $name, array $params = []): Testable
     {
-        if (! static::$viewsAreCached) {
-            Artisan::call('view:cache');
-
-            static::$viewsAreCached = true;
-        }
+        $this->ensureViewsAreCached();
 
         if (FragmentMap::has($name)) {
             $name = FragmentMap::get($name);
         }
 
         return Livewire::test($name, $params);
+    }
+
+    /**
+     * Ensure that the views are cached for testing.
+     */
+    public function ensureViewsAreCached(): void
+    {
+        if (! static::$viewsAreCached) {
+            Artisan::call('view:cache');
+
+            static::$viewsAreCached = true;
+        }
     }
 
     /**

--- a/src/VoltServiceProvider.php
+++ b/src/VoltServiceProvider.php
@@ -5,6 +5,7 @@ namespace Livewire\Volt;
 use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\Facades\Facade;
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Testing\TestResponse;
 use Livewire\Livewire;
 use Livewire\LivewireServiceProvider;
 use Livewire\Volt\Precompilers\ExtractFragments;
@@ -36,6 +37,7 @@ class VoltServiceProvider extends ServiceProvider
     {
         $this->registerCommands();
         $this->registerPublishing();
+        $this->registerTestingMacros();
 
         Blade::prepareStringsForCompilationUsing(function (string $value) {
             foreach ([ExtractFragments::class, ExtractTemplate::class] as $precompiler) {
@@ -100,5 +102,21 @@ class VoltServiceProvider extends ServiceProvider
                 __DIR__.'/../stubs/VoltServiceProvider.stub' => app_path('Providers/VoltServiceProvider.php'),
             ], 'volt-provider');
         }
+    }
+
+    /**
+     * Register the package's testing macros.
+     */
+    protected function registerTestingMacros(): void
+    {
+        TestResponse::macro('assertSeeVolt', function ($component) {
+            Volt::ensureViewsAreCached();
+
+            if (FragmentMap::has($component)) {
+                $component = FragmentMap::get($component);
+            }
+
+            return $this->assertSeeLivewire($component);
+        });
     }
 }

--- a/tests/Feature/FunctionalComponentTest.php
+++ b/tests/Feature/FunctionalComponentTest.php
@@ -771,3 +771,12 @@ it('allows to define components as routes with custom layout', function () {
         ->assertSee('Layout: custom layout.')
         ->assertSee('Content: content with custom layout.');
 });
+
+test('`assertSeeVolt` testing method', function () {
+    Volt::route('/basic-component', 'basic-component');
+
+    $this->get('/basic-component')
+        ->assertOk()
+        ->assertSeeVolt('basic-component')
+        ->assertOk();
+});

--- a/tests/Feature/FunctionalFolioTest.php
+++ b/tests/Feature/FunctionalFolioTest.php
@@ -149,3 +149,12 @@ test('authorization with mount', function () {
 
     $response->assertStatus(403);
 });
+
+test('`assertSeeVolt` testing method', function () {
+    Folio::route(__DIR__.'/resources/views/functional-api-pages');
+
+    $this->get('/page-with-fragment')
+        ->assertOk()
+        ->assertSeeVolt('fragment-component')
+        ->assertOk();
+});


### PR DESCRIPTION
This pull request fixes https://github.com/livewire/volt/issues/21, by adding a new `assertSeeVolt` that allows you test that a given response contains a fragment:

```php
$this->get('/page-with-@volt-directive')->assertSeeVolt('fragment-component');
```