### PR TITLE
[1.x] Fixes Class API when used with multiple fragments

### DIFF
--- a/src/ComponentFactory.php
+++ b/src/ComponentFactory.php
@@ -33,6 +33,8 @@ class ComponentFactory
         );
 
         if (static::$latestCreatedComponentClass) {
+            opcache_invalidate($path, true);
+            
             return static::$latestCreatedComponentClass;
         }
 

--- a/src/ComponentFactory.php
+++ b/src/ComponentFactory.php
@@ -34,7 +34,7 @@ class ComponentFactory
 
         if (static::$latestCreatedComponentClass) {
             opcache_invalidate($path, true);
-            
+
             return static::$latestCreatedComponentClass;
         }
 


### PR DESCRIPTION
This pull request fixes https://github.com/livewire/volt/issues/25 and addresses the issue with the Class API when used with multiple fragments.

The explanation might be a bit intricate, but if the blade view is already in opcache, the behavior of `new class extends` will differ from subsequent requests after the initial one:

```
// my-component.blade.php...
echo get_class(new class extends A);

// First request with op cache enabled
require 'my-component.blade.php'; // 1111
require 'my-component.blade.php'; // 2222
require 'my-component.blade.php'; // 3333

// Second request with op cache enabled
require 'my-component.blade.php'; // 1111
require 'my-component.blade.php'; // 1111
require 'my-component.blade.php'; // 1111
```

So, this pull request simply "invalidates" the opcache for any given blade view path that contains a class, so basically the behavior don't change between requests:

```
// my-component.blade.php...
echo get_class(new class extends A);

// First request with op cache enabled
require 'my-component.blade.php'; // 1111
require 'my-component.blade.php'; // 2222
require 'my-component.blade.php'; // 3333

// Second request with op cache enabled
require 'my-component.blade.php'; // 1111
require 'my-component.blade.php'; // 2222
require 'my-component.blade.php'; // 3333
```
