### PR TITLE
Avoid throwing error when OpCache isn't installed

### DIFF
--- a/src/ComponentFactory.php
+++ b/src/ComponentFactory.php
@@ -33,7 +33,9 @@ class ComponentFactory
         );
 
         if (static::$latestCreatedComponentClass) {
-            opcache_invalidate($path, true);
+            if (function_exists('opcache_invalidate')) {
+                opcache_invalidate($path, true);
+            }
 
             return static::$latestCreatedComponentClass;
         }


### PR DESCRIPTION
fixes #27 

```
Call to undefined function Livewire\Volt\opcache_invalidate()
```

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
