### PR TITLE
[1.x] Adds `with` method to the class API

### DIFF
--- a/src/Component.php
+++ b/src/Component.php
@@ -41,7 +41,7 @@ abstract class Component extends LivewireComponent
 
         $data = $this instanceof FunctionalComponent
             ? (new ReturnViewData)->execute(static::$__context, $this, []) // @phpstan-ignore-line
-            : [];
+            : (method_exists($this, 'with') ? Container::getInstance()->call([$this, 'with']) : []);
 
         $layout = $this instanceof FunctionalComponent
             ? (new ReturnLayout)->execute(static::$__context, $this, []) // @phpstan-ignore-line

--- a/tests/Feature/ClassComponentTest.php
+++ b/tests/Feature/ClassComponentTest.php
@@ -83,3 +83,28 @@ it('allows to define components as routes with custom layout', function () {
         ->assertSee('Layout: custom layout.')
         ->assertSee('Content: content with custom layout.');
 });
+
+class PlusOne {
+    public function __invoke($value)
+    {
+        return $value + 1;
+    }
+}
+
+it('may have data', function () {
+    $component = Livewire::test('component-with-data');
+
+    $component->assertSeeHtml([
+        '<li>Counter Plus Zero: 3.</li>',
+        '<li>Counter Plus One: 4.</li>',
+        '<li>Counter Collection: 0, 1, 2, 3.</li>',
+    ]);
+
+    $component->set('counter', 10);
+
+    $component->assertSeeHtml([
+        '<li>Counter Plus Zero: 13.</li>',
+        '<li>Counter Plus One: 14.</li>',
+        '<li>Counter Collection: 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13.</li>',
+    ]);
+});

--- a/tests/Feature/ClassComponentTest.php
+++ b/tests/Feature/ClassComponentTest.php
@@ -84,7 +84,8 @@ it('allows to define components as routes with custom layout', function () {
         ->assertSee('Content: content with custom layout.');
 });
 
-class PlusOne {
+class PlusOne
+{
     public function __invoke($value)
     {
         return $value + 1;

--- a/tests/Feature/resources/views/class-api/component-with-data.blade.php
+++ b/tests/Feature/resources/views/class-api/component-with-data.blade.php
@@ -1,0 +1,30 @@
+<?php
+
+use Livewire\Volt\Component;
+
+new class extends Component
+{
+    public $counter = 0;
+
+    public function increment()
+    {
+        $this->counter++;
+    }
+
+    public function with(PlusOne $plusOne)
+    {
+        return [
+            'counterPlusZero' => $this->counter + $plusOne->__invoke(2),
+            'counterPlusOne' => $this->counter + 1 + $plusOne->__invoke(2),
+            'counterCollection' => collect(range(0, $this->counter + $plusOne->__invoke(2))),
+        ];
+    }
+} ?>
+
+<div>
+    <ul>
+        <li>Counter Plus Zero: {{ $counterPlusZero }}.</li>
+        <li>Counter Plus One: {{ $counterPlusOne }}.</li>
+        <li>Counter Collection: {{ $counterCollection->implode(', ') }}.</li>
+    </ul>
+</div>


### PR DESCRIPTION
> Addresses https://github.com/livewire/livewire/pull/6406.

This pull request adds the `with` method to the class API, so it can be used to render `data` on the view. Example:

```php
<?php
 
namespace App\Livewire;
 
use Livewire\WithPagination;
use Livewire\Volt\Component;
use App\Models\Post;
 
new class extends Component
{
    use WithPagination;
 
    public function with()
    {
        return [
            'posts' => Post::paginate(10),
        ];
    }
}
```

