### PR TITLE
[1.x] Fixes sending "name" as property hook argument

### DIFF
--- a/src/Compilers/PublicMethods.php
+++ b/src/Compilers/PublicMethods.php
@@ -94,7 +94,7 @@ class PublicMethods implements Compiler
             ->map(fn (string $hook) => <<<PHP
                 public function {$hook}(\$name)
                 {
-                    \$arguments = [static::\$__context, \$this, func_get_args()];
+                    \$arguments = [static::\$__context, \$this, array_slice(func_get_args(), 1)];
 
                     return (new Actions\CallPropertyHook('$hook', \$name))->execute(...\$arguments);
                 }

--- a/tests/Feature/Compiler/DehydrateTest.php
+++ b/tests/Feature/Compiler/DehydrateTest.php
@@ -36,7 +36,7 @@ it('may be defined for a property', function () {
     expect($code)->toContain(<<<'PHP'
         public function dehydrateProperty($name)
         {
-            $arguments = [static::$__context, $this, func_get_args()];
+            $arguments = [static::$__context, $this, array_slice(func_get_args(), 1)];
 
             return (new Actions\CallPropertyHook('dehydrateProperty', $name))->execute(...$arguments);
         }

--- a/tests/Feature/Compiler/HydrateTest.php
+++ b/tests/Feature/Compiler/HydrateTest.php
@@ -36,7 +36,7 @@ it('may be defined for a property', function () {
     expect($code)->toContain(<<<'PHP'
         public function hydrateProperty($name)
         {
-            $arguments = [static::$__context, $this, func_get_args()];
+            $arguments = [static::$__context, $this, array_slice(func_get_args(), 1)];
 
             return (new Actions\CallPropertyHook('hydrateProperty', $name))->execute(...$arguments);
         }

--- a/tests/Feature/Compiler/UpdatedTest.php
+++ b/tests/Feature/Compiler/UpdatedTest.php
@@ -13,7 +13,7 @@ it('may not be defined', function () {
 
 it('may be defined', function () {
     updated(name: fn () => null);
-    
+
     $code = Compiler::contextToString(CompileContext::instance());
 
     expect($code)->toContain(<<<'PHP'

--- a/tests/Feature/Compiler/UpdatedTest.php
+++ b/tests/Feature/Compiler/UpdatedTest.php
@@ -13,13 +13,13 @@ it('may not be defined', function () {
 
 it('may be defined', function () {
     updated(name: fn () => null);
-
+    
     $code = Compiler::contextToString(CompileContext::instance());
 
     expect($code)->toContain(<<<'PHP'
         public function updated($name)
         {
-            $arguments = [static::$__context, $this, func_get_args()];
+            $arguments = [static::$__context, $this, array_slice(func_get_args(), 1)];
 
             return (new Actions\CallPropertyHook('updated', $name))->execute(...$arguments);
         }

--- a/tests/Feature/Compiler/UpdatingTest.php
+++ b/tests/Feature/Compiler/UpdatingTest.php
@@ -19,7 +19,7 @@ it('may be defined', function () {
     expect($code)->toContain(<<<'PHP'
         public function updating($name)
         {
-            $arguments = [static::$__context, $this, func_get_args()];
+            $arguments = [static::$__context, $this, array_slice(func_get_args(), 1)];
 
             return (new Actions\CallPropertyHook('updating', $name))->execute(...$arguments);
         }


### PR DESCRIPTION
This pull request fixes an issue on property hook arguments, where the property "name" was been sent as argument:

```php
// before
updated(query: fn (string $name, string $newValue) => /** ... */); ?>
// after
updated(query: fn (string $newValue) => /** ... */); ?>
```

Note that having `$name` there does not make sense - as the hook is only fired for the `query` property as specified.