### PR TITLE
[1.x] Fixes bottom script being included as template

### DIFF
--- a/src/Precompilers/ExtractTemplate.php
+++ b/src/Precompilers/ExtractTemplate.php
@@ -44,15 +44,21 @@ class ExtractTemplate
      */
     protected function imports(string $template): string
     {
-        $phpScript = trim(preg_replace('/.*<\?php\s*(.*?)\s*\?>.*/s', '$1', $template));
-        $phpScript = trim(preg_replace('/^(?!use\s+.*?;).*$/m', '', $phpScript));
-        $phpScript = trim(preg_replace('/^use\s+function\s+Livewire\\\\Volt.*$/m', '', $phpScript));
+        preg_match_all('/<\?php\s*(.*?)\s*\?>/s', $template, $matches);
 
-        if (! empty($phpScript)) {
-            $phpScript = '<?php'."\n\n".$phpScript."\n\n".'?>'."\n\n";
+        $script = collect($matches[1])
+            ->map(fn (string $script) => trim($script))
+            ->reject(fn (string $script) => empty($script))
+            ->implode("\n");
+
+        $script = trim(preg_replace('/^(?!use\s+.*?;).*$/m', '', $script));
+        $script = trim(preg_replace('/^use\s+function\s+Livewire\\\\Volt.*$/m', '', $script));
+
+        if (! empty($script)) {
+            $script = '<?php'."\n\n".$script."\n\n".'?>'."\n\n";
         }
 
-        return $phpScript;
+        return $script;
     }
 
     /**
@@ -60,7 +66,9 @@ class ExtractTemplate
      */
     protected function html(string $template): string
     {
-        return trim(preg_replace('/<\?php\s*(.*?)\s*\?>/s', '', $template));
+        $template = trim(preg_replace('/<\?php\s*(.*?)\s*\?>/s', '', $template));
+
+        return str($template)->beforeLast('<?php')->trim()->value();
     }
 
     /**

--- a/tests/.pest/snapshots/Feature/FunctionalComponentTest/generated_code_with_data_set__dataset__component_with_user_imports_blade_php______tests_Feature_resources_view___de_php__.snap
+++ b/tests/.pest/snapshots/Feature/FunctionalComponentTest/generated_code_with_data_set__dataset__component_with_user_imports_blade_php______tests_Feature_resources_view___de_php__.snap
@@ -1,0 +1,32 @@
+<?php
+
+use Livewire\Volt\Actions;
+use Livewire\Volt\CompileContext;
+use Livewire\Volt\Contracts\Compiled;
+use Livewire\Volt\Component;
+
+new class extends Component implements Livewire\Volt\Contracts\FunctionalComponent
+{
+    public static CompileContext $__context;
+
+    use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+
+    public $name;
+
+    public $counter;
+
+    public function mount($name = NULL)
+    {
+        (new Actions\InitializeState)->execute(static::$__context, $this, get_defined_vars());
+
+        (new Actions\CallHook('mount'))->execute(static::$__context, $this, get_defined_vars());
+    }
+
+    public function increment()
+    {
+        $arguments = [static::$__context, $this, func_get_args()];
+
+        return (new Actions\CallMethod('increment'))->execute(...$arguments);
+    }
+
+};

--- a/tests/Feature/FunctionalComponentTest.php
+++ b/tests/Feature/FunctionalComponentTest.php
@@ -17,6 +17,7 @@ use Livewire\Volt\ComponentResolver;
 use Livewire\Volt\Volt;
 use Pest\TestSuite;
 use Tests\Fixtures\GlobalTrait;
+use Tests\Fixtures\User;
 
 beforeEach(function () {
     View::setFinder(new FileViewFinder(app()['files'], [__DIR__.'/resources/views']));
@@ -788,4 +789,19 @@ test('`assertSeeVolt` testing method', function () {
         ->assertOk()
         ->assertSeeVolt('basic-component')
         ->assertOk();
+});
+
+test('user imports on bottom do not conflict', function () {
+    User::create([
+        'name' => 'Taylor',
+        'email' => 'taylor@laravel.com',
+        'password' => 'password',
+    ]);
+
+    Livewire::test('component-with-user-imports', ['name' => 'Taylor'])
+        ->assertSet('counter', 0)
+        ->call('increment')
+        ->call('increment')
+        ->call('increment')
+        ->assertSet('counter', 3);
 });

--- a/tests/Feature/resources/views/functional-api/component-with-user-imports.blade.php
+++ b/tests/Feature/resources/views/functional-api/component-with-user-imports.blade.php
@@ -1,0 +1,21 @@
+<div>
+    Hello {{ $name }}
+    <br/>
+    Counter: {{ $counter }}
+    <br/>
+    <button wire:click="increment">
+        Increment Counter
+    </button>
+</div>
+
+<?php
+
+use Tests\Fixtures\User;
+use function Livewire\Volt\mount;
+use function Livewire\Volt\state;
+
+state(name: '', counter: 0);
+
+mount(fn ($name = null) => $this->name = $name ?? User::first()->name);
+
+$increment = fn () => $this->counter++;

--- a/tests/Unit/Precompilers/ExtractTemplateTest.php
+++ b/tests/Unit/Precompilers/ExtractTemplateTest.php
@@ -96,3 +96,309 @@ it('does not allow "return new class extends Component" ending execution', funct
 
     $this->precompiler->__invoke($template);
 })->throws(ReturnNewClassExecutionEndingException::class);
+
+$conflictsDataset = collect([
+    [<<<'HTML'
+        <?php
+
+        use App;
+
+        ?>
+
+        <div/>
+        HTML, <<<'HTML'
+        <?php
+
+        use App;
+
+        ?>
+
+        <div/>
+        HTML,
+    ], // ---
+    [<<<'HTML'
+        <?php
+
+        use App; ?>
+
+        <div/>
+        HTML, <<<'HTML'
+        <?php
+
+        use App;
+
+        ?>
+
+        <div/>
+        HTML
+    ], // ---
+    [<<<'HTML'
+        <?php
+
+        use App;
+        use function Livewire\Volt\{state}; ?>
+
+        <div/>
+        HTML, <<<'HTML'
+        <?php
+
+        use App;
+
+        ?>
+
+        <div/>
+        HTML
+    ], // ---
+    [<<<'HTML'
+        <button />
+
+        <?php
+
+        use App;
+
+        ?>
+
+        <div/>
+        HTML, <<<'HTML'
+        <?php
+
+        use App;
+
+        ?>
+
+        <button />
+
+
+
+        <div/>
+        HTML,
+    ], // ---
+    [<<<'HTML'
+        <button />
+
+        <?php
+
+        use App; ?>
+
+        <div/>
+        HTML, <<<'HTML'
+        <?php
+
+        use App;
+
+        ?>
+
+        <button />
+
+
+
+        <div/>
+        HTML
+    ], // ---
+    [<<<'HTML'
+        <button />
+
+        <?php
+
+        use App;
+        use function Livewire\Volt\{state}; ?>
+
+        <div/>
+        HTML, <<<'HTML'
+        <?php
+
+        use App;
+
+        ?>
+
+        <button />
+
+
+
+        <div/>
+        HTML
+    ], // ---
+    [<<<'HTML'
+        <button />
+
+        <?php
+
+        use App\User;
+
+        ?>
+
+        <?php
+
+        use App;
+
+        ?>
+
+        <div/>
+        HTML, <<<'HTML'
+        <?php
+
+        use App\User;
+        use App;
+
+        ?>
+
+        <button />
+
+
+
+
+
+        <div/>
+        HTML,
+    ], // ---
+    [<<<'HTML'
+        <button />
+
+        <?php
+
+        use App\User; ?>
+
+        <?php
+
+        use App; ?>
+
+        <div/>
+        HTML, <<<'HTML'
+        <?php
+
+        use App\User;
+        use App;
+
+        ?>
+
+        <button />
+
+
+
+
+
+        <div/>
+        HTML
+    ], // ---
+    [<<<'HTML'
+        <button />
+
+        <?php
+
+        use App\User;
+
+        ?>
+
+        <?php
+
+        use App;
+        use function Livewire\Volt\{state}; ?>
+
+        <div/>
+        HTML, <<<'HTML'
+        <?php
+
+        use App\User;
+        use App;
+
+        ?>
+
+        <button />
+
+
+
+
+
+        <div/>
+        HTML
+    ], // ---
+    [<<<'HTML'
+        <button />
+
+        <?php
+
+        use App\User;
+
+        ?>
+
+        <div/>
+
+        <?php
+
+        use App;
+        HTML, <<<'HTML'
+        <?php
+
+        use App\User;
+
+        ?>
+
+        <button />
+
+
+
+        <div/>
+        HTML,
+    ], // ---
+    [<<<'HTML'
+        <button />
+
+        <?php
+
+        use App\User; ?>
+
+        <div/>
+
+        <?php
+
+        use App; ?>
+        HTML, <<<'HTML'
+        <?php
+
+        use App\User;
+        use App;
+
+        ?>
+
+        <button />
+
+
+
+        <div/>
+        HTML
+    ], // ---
+    [<<<'HTML'
+        <?php
+
+        use App\User; ?>
+
+        <button />
+
+        <div/>
+
+        <?php
+
+        use App;
+        use function Livewire\Volt\{state};
+        HTML, <<<'HTML'
+        <?php
+
+        use App\User;
+
+        ?>
+
+        <button />
+
+        <div/>
+        HTML
+    ], // ---
+
+])->keyBy(function (array $value) {
+    return htmlspecialchars($value[0]);
+})->toArray();
+
+test('import conflicts', function (string $template, string $expected) {
+    $result = $this->precompiler->__invoke($template);
+
+    expect(trim($result))->toBe($expected);
+})->with($conflictsDataset);

--- a/tests/Unit/Precompilers/ExtractTemplateTest.php
+++ b/tests/Unit/Precompilers/ExtractTemplateTest.php
@@ -392,7 +392,12 @@ $conflictsDataset = collect([
         <div/>
         HTML
     ], // ---
-
+    [<<<'HTML'
+        <span></span>
+        HTML, <<<'HTML'
+        <span></span>
+        HTML
+    ], // ---
 ])->keyBy(function (array $value) {
     return htmlspecialchars($value[0]);
 })->toArray();

--- a/tests/Unit/Precompilers/ExtractTemplateTest.php
+++ b/tests/Unit/Precompilers/ExtractTemplateTest.php
@@ -398,6 +398,17 @@ $conflictsDataset = collect([
         <span></span>
         HTML
     ], // ---
+    [<<<'HTML'
+        HTML, <<<'HTML'
+        HTML
+    ], // ---
+    [<<<'HTML'
+        <?php
+
+        use App;
+        use function Livewire\Volt\{state};
+        HTML, '',
+    ], // ---
 ])->keyBy(function (array $value) {
     return htmlspecialchars($value[0]);
 })->toArray();


### PR DESCRIPTION
This pull request fixes https://github.com/livewire/volt/issues/36, and fixes PHP scripts included on bottom of a Volt component. Because, sometimes, there is no `?>` ending tags, that specific script was not being considered as "script" by our pre-compiler.