### PR TITLE
[1.x] Adds integration tests with `render`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "livewire/livewire": "^3.0"
     },
     "require-dev": {
-        "laravel/folio": "^1.0",
+        "laravel/folio": "^1.1",
         "mockery/mockery": "^1.6",
         "orchestra/testbench": "^8.6.2",
         "pestphp/pest": "^2.9.5",

--- a/tests/Feature/ClassFolioTest.php
+++ b/tests/Feature/ClassFolioTest.php
@@ -113,3 +113,20 @@ test('`@livewireStyles` and `@livewireScripts` blade directives may be used in a
 
     $response->assertStatus(200)->assertSee('Page Livewire Styles and Scripts');
 });
+
+test('page with view content', function () {
+    Folio::route(__DIR__.'/resources/views/class-api-pages');
+
+    $response = $this->get('page-with-view-content');
+
+    $response->assertStatus(200)
+        ->assertSee('Hello from view.');
+});
+
+test('page with authorization on render', function () {
+    Folio::route(__DIR__.'/resources/views/class-api-pages');
+
+    $response = $this->get('authorization-on-render');
+
+    $response->assertStatus(403);
+});

--- a/tests/Feature/FunctionalFolioTest.php
+++ b/tests/Feature/FunctionalFolioTest.php
@@ -139,3 +139,20 @@ test('`assertSeeVolt` testing method', function () {
         ->assertSeeVolt('fragment-component')
         ->assertOk();
 });
+
+test('page with view content', function () {
+    Folio::route(__DIR__.'/resources/views/functional-api-pages');
+
+    $response = $this->get('page-with-view-content');
+
+    $response->assertStatus(200)
+        ->assertSee('Hello from view.');
+});
+
+test('page with authorization on render', function () {
+    Folio::route(__DIR__.'/resources/views/functional-api-pages');
+
+    $response = $this->get('authorization-on-render');
+
+    $response->assertStatus(403);
+});

--- a/tests/Feature/resources/views/class-api-pages/authorization-on-render.blade.php
+++ b/tests/Feature/resources/views/class-api-pages/authorization-on-render.blade.php
@@ -1,0 +1,17 @@
+<?php
+
+use function Laravel\Folio\{render};
+use Livewire\Volt\Component;
+
+render(fn () => abort(403, 'Unauthorized action from middleware'));
+
+new class extends Component
+{
+    public string $content = 'Hello world';
+} ?>
+
+<div>
+    @volt
+        {{ $content }}
+    @endvolt
+</div>

--- a/tests/Feature/resources/views/class-api-pages/authorization-with-mount.blade.php
+++ b/tests/Feature/resources/views/class-api-pages/authorization-with-mount.blade.php
@@ -1,6 +1,6 @@
 <?php
 
-use function Laravel\Folio\middleware;
+use function Laravel\Folio\{middleware, render};
 use Livewire\Volt\Component;
 
 middleware(fn () => abort(403, 'Unauthorized action from middleware'));

--- a/tests/Feature/resources/views/class-api-pages/page-with-view-content.blade.php
+++ b/tests/Feature/resources/views/class-api-pages/page-with-view-content.blade.php
@@ -14,7 +14,7 @@ new class extends Component
 ?>
 
 <div>
-    @volt('fragment-component')
+    @volt
     <div>
         <span>Hello {{ $name }}.</span>
     </div>

--- a/tests/Feature/resources/views/class-api-pages/page-with-view-content.blade.php
+++ b/tests/Feature/resources/views/class-api-pages/page-with-view-content.blade.php
@@ -1,0 +1,22 @@
+<?php
+
+use Livewire\Volt\Component;
+
+use function Laravel\Folio\{render};
+
+render(fn ($view) => $view->with('name', 'from view'));
+
+new class extends Component
+{
+    public string $name = 'from component';
+}
+
+?>
+
+<div>
+    @volt('fragment-component')
+    <div>
+        <span>Hello {{ $name }}.</span>
+    </div>
+    @endvolt
+</div>

--- a/tests/Feature/resources/views/functional-api-pages/authorization-on-render.blade.php
+++ b/tests/Feature/resources/views/functional-api-pages/authorization-on-render.blade.php
@@ -1,0 +1,14 @@
+<?php
+
+use function Laravel\Folio\{render};
+use function Livewire\Volt\{state};
+
+render(fn () => abort(403, 'Unauthorized action from middleware'));
+
+state('content', 'Hello world'); ?>
+
+<div>
+    @volt
+        {{ $content }}
+    @endvolt
+</div>

--- a/tests/Feature/resources/views/functional-api-pages/page-with-view-content.blade.php
+++ b/tests/Feature/resources/views/functional-api-pages/page-with-view-content.blade.php
@@ -10,7 +10,7 @@ render(fn ($view) => $view->with('name', 'from view'));
 state('name', 'from component'); ?>
 
 <div>
-    @volt('fragment-component')
+    @volt
     <div>
         <span>Hello {{ $name }}.</span>
     </div>

--- a/tests/Feature/resources/views/functional-api-pages/page-with-view-content.blade.php
+++ b/tests/Feature/resources/views/functional-api-pages/page-with-view-content.blade.php
@@ -1,0 +1,18 @@
+<?php
+
+use Livewire\Volt\Component;
+
+use function Livewire\Volt\{state};
+use function Laravel\Folio\{render};
+
+render(fn ($view) => $view->with('name', 'from view'));
+
+state('name', 'from component'); ?>
+
+<div>
+    @volt('fragment-component')
+    <div>
+        <span>Hello {{ $name }}.</span>
+    </div>
+    @endvolt
+</div>


### PR DESCRIPTION
This pull request adds integration tests with Folio's new `render` function: https://github.com/laravel/folio/pull/100.