### PR TITLE
Fixing Bug in Precompiler when Blade::getPath() is null

### DIFF
--- a/src/Precompilers/ExtractTemplate.php
+++ b/src/Precompilers/ExtractTemplate.php
@@ -36,7 +36,11 @@ class ExtractTemplate
      */
     protected function shouldExtractTemplate(string $template): bool
     {
-        return $this->mountedDirectories->isWithinMountedDirectory(Blade::getPath());
+        if (is_null($path = Blade::getPath())) {
+            return false;
+        }
+
+        return $this->mountedDirectories->isWithinMountedDirectory($path);
     }
 
     /**


### PR DESCRIPTION
Good evening!

This bug happens if I have Volt installed in my project, and try to compile a blade string in some part of the code where the blade path will be null.

Try this in some part of the Project where the blade path is already null:
Blade::compileString('<h1>Test</h1>');

Error:
![image](https://github.com/livewire/volt/assets/45684782/8a67950f-9b05-4f15-a565-852754b0363a)
