### PR TITLE
[1.x] Adds `withQueryParams`

### DIFF
--- a/src/VoltManager.php
+++ b/src/VoltManager.php
@@ -96,4 +96,14 @@ class VoltManager
     {
         return $this->mountedDirectories->paths();
     }
+
+    /**
+     * Set the query params for testing.
+     */
+    public function withQueryParams(array $params): static
+    {
+        $this->manager->withQueryParams($params);
+
+        return $this;
+    }
 }

--- a/src/VoltManager.php
+++ b/src/VoltManager.php
@@ -76,6 +76,16 @@ class VoltManager
     }
 
     /**
+     * Define the query parameters for testing.
+     */
+    public function withQueryParams(array $params): static
+    {
+        $this->manager->withQueryParams($params);
+
+        return $this;
+    }
+
+    /**
      * Ensure that the views are cached for testing.
      */
     public function ensureViewsAreCached(): void
@@ -95,15 +105,5 @@ class VoltManager
     public function paths(): array
     {
         return $this->mountedDirectories->paths();
-    }
-
-    /**
-     * Set the query params for testing.
-     */
-    public function withQueryParams(array $params): static
-    {
-        $this->manager->withQueryParams($params);
-
-        return $this;
     }
 }

--- a/tests/Feature/FunctionalComponentTest.php
+++ b/tests/Feature/FunctionalComponentTest.php
@@ -105,6 +105,20 @@ it('can have parameters', function (array $parameters, array $state) {
     [['string' => 'overridden-string', 'null' => 'overridden-null'], ['string' => 'overridden-string', 'null' => 'overridden-null']],
 ]);
 
+it('can have query parameters', function () {
+    $component = Volt::withQueryParams(['search' => 'Nuno'])
+        ->test('component-with-url-state');
+
+    $component->assertSeeHtml([
+        '<li>Nuno Maduro</li>',
+        '<li>Nuno</li>',
+    ]);
+
+    $component->assertDontSeeHtml([
+        '<li>Taylor</li>',
+    ]);
+})->only();
+
 it('can have locked state', function () {
     $component = Livewire::test('component-with-locked-state');
 


### PR DESCRIPTION
This pull request adds `withQueryParams` to the `Volt::test` API: https://livewire.laravel.com/docs/testing#setting-url-parameters.

Fixes https://github.com/livewire/volt/issues/50.