### PR TITLE
[1.x] Adds tests around php blocks

### DIFF
--- a/tests/Feature/AnonymousComponentTest.php
+++ b/tests/Feature/AnonymousComponentTest.php
@@ -23,6 +23,11 @@ it('may be tested', function () {
         ->assertSee('Second - Hello Taylor');
 });
 
+it('may have php blocks', function () {
+    Volt::test('fragment-component-with-php-blocks')
+        ->assertSee('Hello Nuno');
+});
+
 it('may be lazy', function () {
     Folio::route(__DIR__.'/resources/views/functional-api-pages');
 

--- a/tests/Feature/resources/views/functional-api-pages/page-with-fragment-and-php-blocks.blade.php
+++ b/tests/Feature/resources/views/functional-api-pages/page-with-fragment-and-php-blocks.blade.php
@@ -1,0 +1,11 @@
+<div>
+    @volt('fragment-component-with-php-blocks')
+    <div>
+        @php
+            $name = 'Nuno';
+        @endphp
+
+        Hello {{ $name }}
+    </div>
+    @endvolt
+</div>


### PR DESCRIPTION
This pull request add a test that allows the use of regular `@php` blocks within volt's anonymous components.