### PR TITLE
[1.x] Adds `actingAs` to Volt facade

### DIFF
--- a/src/Volt.php
+++ b/src/Volt.php
@@ -9,7 +9,8 @@ use Illuminate\Support\Facades\Facade;
  * @method static void mount(array|string $paths = [], array|string $uses = [])
  * @method static array paths()
  * @method static \Livewire\Features\SupportTesting\Testable test(string $name, array $params = [])
- * @method static self withQueryParams(array $params = [])
+ * @method static static actingAs(\Illuminate\Contracts\Auth\Authenticatable $user, ?string $driver = null)
+ * @method static static withQueryParams(array $params = [])
  * @method static \Illuminate\Routing\Route route(string $uri, string $componentName)
  */
 class Volt extends Facade

--- a/src/VoltManager.php
+++ b/src/VoltManager.php
@@ -3,6 +3,7 @@
 namespace Livewire\Volt;
 
 use Illuminate\Container\Container;
+use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Contracts\Routing\Registrar;
 use Illuminate\Routing\Route;
 use Illuminate\Support\Facades\Artisan;
@@ -81,6 +82,16 @@ class VoltManager
     public function withQueryParams(array $params): static
     {
         $this->manager->withQueryParams($params);
+
+        return $this;
+    }
+
+    /**
+     * Set the currently logged in user for the application.
+     */
+    public function actingAs(Authenticatable $user, string $driver = null): static
+    {
+        $this->manager->actingAs($user, $driver);
 
         return $this;
     }

--- a/tests/.pest/snapshots/Feature/FunctionalComponentTest/generated_code_with_data_set__dataset__component_with_logged_user_blade_php______tests_Feature_resources_view___de_php__.snap
+++ b/tests/.pest/snapshots/Feature/FunctionalComponentTest/generated_code_with_data_set__dataset__component_with_logged_user_blade_php______tests_Feature_resources_view___de_php__.snap
@@ -1,0 +1,21 @@
+<?php
+
+use Livewire\Volt\Actions;
+use Livewire\Volt\CompileContext;
+use Livewire\Volt\Contracts\Compiled;
+use Livewire\Volt\Component;
+
+new class extends Component implements Livewire\Volt\Contracts\FunctionalComponent
+{
+    public static CompileContext $__context;
+
+    use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+
+    public function mount()
+    {
+        (new Actions\InitializeState)->execute(static::$__context, $this, get_defined_vars());
+
+        (new Actions\CallHook('mount'))->execute(static::$__context, $this, get_defined_vars());
+    }
+
+};

--- a/tests/Feature/FunctionalComponentTest.php
+++ b/tests/Feature/FunctionalComponentTest.php
@@ -119,6 +119,16 @@ it('can have query parameters', function () {
     ]);
 });
 
+it('can act as logged user', function () {
+    $user = new User([
+        'name' => 'Taylor',
+    ]);
+
+    Livewire::actingAs($user)
+        ->test('component-with-logged-user')
+        ->assertSee('Hello Taylor.');
+});
+
 it('can have locked state', function () {
     $component = Livewire::test('component-with-locked-state');
 

--- a/tests/Feature/resources/views/functional-api/component-with-logged-user.blade.php
+++ b/tests/Feature/resources/views/functional-api/component-with-logged-user.blade.php
@@ -1,0 +1,3 @@
+<div>
+    Hello {{ auth()->user()->name }}.
+</div>


### PR DESCRIPTION
This pull request a missing `actingAs` method to the Volt's facade.