### PR TITLE
[1.x] Fixes imports used on fragments

### DIFF
--- a/src/CompilerVersion.php
+++ b/src/CompilerVersion.php
@@ -7,5 +7,5 @@ class CompilerVersion
     /**
      * The current version of the Volt's compiler.
      */
-    public const NUMBER = 2;
+    public const NUMBER = 3;
 }

--- a/src/Precompilers/Concerns/ExtractsImports.php
+++ b/src/Precompilers/Concerns/ExtractsImports.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Livewire\Volt\Precompilers\Concerns;
+
+trait ExtractsImports
+{
+    /**
+     * Extract the PHP "use" statements from the given template.
+     */
+    protected function imports(string $template): string
+    {
+        preg_match_all('/<\?php\s*(.*?)\s*\?>/s', $template, $matches);
+
+        $script = collect($matches[1])
+            ->map(fn (string $script) => trim($script))
+            ->reject(fn (string $script) => empty($script))
+            ->implode("\n");
+
+        $script = trim(preg_replace('/^(?!use\s+.*?;).*$/m', '', $script));
+        $script = trim(preg_replace('/^use\s+function\s+Livewire\\\\Volt.*$/m', '', $script));
+
+        if (! empty($script)) {
+            $script = '<?php'."\n\n".$script."\n\n".'?>'."\n\n";
+        }
+
+        return $script;
+    }
+}

--- a/src/Precompilers/ExtractTemplate.php
+++ b/src/Precompilers/ExtractTemplate.php
@@ -9,6 +9,8 @@ use Livewire\Volt\Volt;
 
 class ExtractTemplate
 {
+    use Concerns\ExtractsImports;
+
     /**
      * Create a new precompiler instance.
      */
@@ -41,28 +43,6 @@ class ExtractTemplate
         }
 
         return $this->mountedDirectories->isWithinMountedDirectory($path);
-    }
-
-    /**
-     * Extract the PHP "use" statements from the given template.
-     */
-    protected function imports(string $template): string
-    {
-        preg_match_all('/<\?php\s*(.*?)\s*\?>/s', $template, $matches);
-
-        $script = collect($matches[1])
-            ->map(fn (string $script) => trim($script))
-            ->reject(fn (string $script) => empty($script))
-            ->implode("\n");
-
-        $script = trim(preg_replace('/^(?!use\s+.*?;).*$/m', '', $script));
-        $script = trim(preg_replace('/^use\s+function\s+Livewire\\\\Volt.*$/m', '', $script));
-
-        if (! empty($script)) {
-            $script = '<?php'."\n\n".$script."\n\n".'?>'."\n\n";
-        }
-
-        return $script;
     }
 
     /**

--- a/tests/Feature/AnonymousComponentTest.php
+++ b/tests/Feature/AnonymousComponentTest.php
@@ -67,3 +67,8 @@ it('throws component not found exception when the component alias was tampered',
     ComponentNotFoundException::class,
     'Unable to find component'
 );
+
+it('may use imports from page definition', function () {
+    Volt::test('fragment-component-using-imports-on-template')
+        ->assertSee('In fragment: published.');
+});

--- a/tests/Feature/FunctionalFolioTest.php
+++ b/tests/Feature/FunctionalFolioTest.php
@@ -124,6 +124,16 @@ test('folio imports dont conflict with fragments imports', function () {
         ->assertSee('Taylor');
 });
 
+test('imports may be used', function () {
+    Folio::route(__DIR__.'/resources/views/functional-api-pages');
+
+    $response = $this->get('page-with-fragment-using-imports-on-template');
+
+    $response->assertStatus(200)
+        ->assertSee('Out fragment: draft.')
+        ->assertSee('In fragment: published.');
+});
+
 test('authorization with mount', function () {
     Folio::route(__DIR__.'/resources/views/functional-api-pages');
 

--- a/tests/Feature/resources/views/functional-api-pages/page-with-fragment-using-imports-on-template.blade.php
+++ b/tests/Feature/resources/views/functional-api-pages/page-with-fragment-using-imports-on-template.blade.php
@@ -1,0 +1,15 @@
+<?php
+
+use Tests\Fixtures\Status;
+
+?>
+
+<div>
+    Out fragment: {{ Status::DRAFT }}.
+
+    @volt('fragment-component-using-imports-on-template')
+        <div>
+            In fragment: {{ Status::PUBLISHED }}.
+        </div>
+    @endvolt
+</div>

--- a/tests/Fixtures/Status.php
+++ b/tests/Fixtures/Status.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Tests\Fixtures;
+
+enum Status: string
+{
+    case DRAFT = 'draft';
+    case PUBLISHED = 'published';
+    case ARCHIVED = 'archived';
+}


### PR DESCRIPTION
Fixes https://github.com/livewire/volt/issues/62.

This pull requests fixes an issue where imports of the page/view definition where not being used on the compiled fragment's template.