### PR TITLE
[1.x] Removes custom `rendering` call

### DIFF
--- a/src/Component.php
+++ b/src/Component.php
@@ -7,7 +7,6 @@ use BadMethodCallException;
 use Illuminate\Container\Container;
 use Illuminate\Support\Facades;
 use Illuminate\Support\Str;
-use Illuminate\View\View;
 use Livewire\Component as LivewireComponent;
 use Livewire\Mechanisms\ComponentRegistry;
 use Livewire\Volt\Actions\ReturnLayout;

--- a/src/Component.php
+++ b/src/Component.php
@@ -65,14 +65,6 @@ abstract class Component extends LivewireComponent
             $view->title($title);
         }
 
-        return $this->rendering($view);
-    }
-
-    /**
-     * Triggered before the component is rendered.
-     */
-    public function rendering(View $view): View
-    {
         return $view;
     }
 


### PR DESCRIPTION
Fixes https://github.com/livewire/volt/issues/64.

We've not noticed, but Livewire already calls the `rendering` method. 