### PR TITLE
[1.x] Fix defining rules using a closure

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -15,6 +15,7 @@ use Livewire\Volt\Methods\ProtectedMethod;
 use Livewire\Volt\Options\RuleOptions;
 use Livewire\Volt\Options\StateOptions;
 use Livewire\Volt\Options\UsesOptions;
+use function is_callable;
 
 /**
  * Define the component's state.
@@ -261,7 +262,11 @@ function on(Closure|array|string ...$listeners): void
 function rules(mixed ...$rules): RuleOptions
 {
     if (count($rules) === 1 && array_key_exists(0, $rules)) {
-        $rules = $rules[0];
+        if (is_callable($rules[0])) {
+            $rules = $rules[0]();
+        } else {
+            $rules = $rules[0];
+        }
     }
 
     CompileContext::instance()->rules = array_merge(

--- a/tests/Feature/CompilerContext/RulesTest.php
+++ b/tests/Feature/CompilerContext/RulesTest.php
@@ -43,3 +43,17 @@ test('precedence', function () {
         'email' => 'first',
     ]);
 });
+
+test('may be defined with mixed methods', function () {
+    $context = CompileContext::instance();
+
+    rules(['name' => 'required|min:6']);
+    rules(fn () => [
+        'email' => 'nullable|email',
+    ]);
+
+    expect($context->rules)->toBe([
+        'name' => 'required|min:6',
+        'email' => 'nullable|email',
+    ]);
+});


### PR DESCRIPTION
This PR fixes rules being unable to be defined using a closure as defined in the [Volt documentation](https://livewire.laravel.com/docs/volt#validation).

By evaluating the closure we can get the defined rules, which then get merged into the rules like normal.

I opted not to use a ternary for the `is_callable` function call for readability. If you want this to be a ternary, let me know and I'll push a commit for that.

I also see that the tests are failing, I was able to reproduce that locally and fixed it by creating `workbench/resources/views` directory (`mkdir -p workbench/resources/views` from the project). Would you like me to add that to this branch or rather have a separate branch for that?

Fixes #66 