### PR TITLE
[1.x] Fixes rules missing exception message

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     "require-dev": {
         "laravel/folio": "^1.1",
         "mockery/mockery": "^1.6",
-        "orchestra/testbench": "^8.6.2",
+        "orchestra/testbench": "^8.15.0",
         "pestphp/pest": "^2.9.5",
         "phpstan/phpstan": "^1.10"
     },

--- a/src/Actions/CallMethod.php
+++ b/src/Actions/CallMethod.php
@@ -3,7 +3,6 @@
 namespace Livewire\Volt\Actions;
 
 use Closure;
-use Livewire\Exceptions\MissingRulesException;
 use Livewire\Exceptions\PropertyNotFoundException;
 use Livewire\Volt\CompileContext;
 use Livewire\Volt\Component;
@@ -41,10 +40,6 @@ class CallMethod implements Action
             Reflection::setExceptionMessage(
                 $e, "State definition for [$propertyName] not found on component [{$component->voltComponentName()}]."
             );
-
-            throw $e;
-        } catch (MissingRulesException $e) {
-            Reflection::setExceptionMessage($e, "[rules()] declaration not found in [{$component->voltComponentName()}].");
 
             throw $e;
         }

--- a/src/LivewireManager.php
+++ b/src/LivewireManager.php
@@ -3,6 +3,7 @@
 namespace Livewire\Volt;
 
 use Livewire\Exceptions\MethodNotFoundException;
+use Livewire\Exceptions\MissingRulesException;
 use Livewire\LivewireManager as BaseLivewireManager;
 use Livewire\Volt\Actions\InitializeState;
 use Livewire\Volt\Support\Reflection;
@@ -41,6 +42,17 @@ class LivewireManager extends BaseLivewireManager
                 )), fn () => throw $e)['method'];
 
                 Reflection::setExceptionMessage($e, "Method or action [$method] does not exist on component [{$componentInstance->voltComponentName()}].");
+            }
+
+            throw $e;
+        } catch (MissingRulesException $e) {
+            $componentInstance = $this->current();
+
+            if ($componentInstance instanceof Component) {
+                Reflection::setExceptionMessage(
+                    $e,
+                    "Missing [\$rules/rules()] property/method on: [{$componentInstance->voltComponentName()}].",
+                );
             }
 
             throw $e;

--- a/tests/Feature/ClassComponentTest.php
+++ b/tests/Feature/ClassComponentTest.php
@@ -55,7 +55,7 @@ it('throws exception when rules are not found', function () {
         ->call('store');
 })->throws(
     MissingRulesException::class,
-    'Missing [$rules/rules()] property/method on Livewire component: [component-with-missing-rules].',
+    'Missing [$rules/rules()] property/method on: [component-with-missing-rules].',
 );
 
 it('throws exception when method is not found within action', function () {

--- a/tests/Feature/FunctionalComponentTest.php
+++ b/tests/Feature/FunctionalComponentTest.php
@@ -318,7 +318,7 @@ it('throws exception when rules are not found', function () {
         ->call('store');
 })->throws(
     MissingRulesException::class,
-    '[rules()] declaration not found in [component-with-missing-rules].',
+    'Missing [$rules/rules()] property/method on: [component-with-missing-rules].',
 );
 
 it('throws exception when method is not found within action', function () {


### PR DESCRIPTION
This pull request fixes rules missing exception message, after recent changes on Workbench and Livewire 3 (https://github.com/livewire/livewire/pull/7266).