### PR TITLE
[1.x] Allows to specify rules as closure

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -261,6 +261,12 @@ function on(Closure|array|string ...$listeners): void
 function rules(mixed ...$rules): RuleOptions
 {
     if (count($rules) === 1 && array_key_exists(0, $rules)) {
+        if ($rules[0] instanceof Closure) {
+            CompileContext::instance()->rules = $rules[0];
+
+            return new RuleOptions;
+        }
+
         $rules = $rules[0];
     }
 

--- a/src/Actions/ReturnRules.php
+++ b/src/Actions/ReturnRules.php
@@ -2,6 +2,8 @@
 
 namespace Livewire\Volt\Actions;
 
+use Closure;
+use Illuminate\Container\Container;
 use Livewire\Volt\CompileContext;
 use Livewire\Volt\Component;
 use Livewire\Volt\Contracts\Action;
@@ -13,6 +15,12 @@ class ReturnRules implements Action
      */
     public function execute(CompileContext $context, Component $component, array $arguments): array
     {
+        if ($context->rules instanceof Closure) {
+            return Container::getInstance()->call(
+                Closure::bind($context->rules, $component, $component::class),
+            );
+        }
+
         return $context->rules;
     }
 }

--- a/src/CompileContext.php
+++ b/src/CompileContext.php
@@ -23,7 +23,7 @@ class CompileContext
         public ?string $title,
         public ?Closure $listeners,
         public array $inlineListeners,
-        public array $rules,
+        public Closure|array $rules,
         public array $messages,
         public array $validationAttributes,
         public ?string $paginationView,

--- a/tests/.pest/snapshots/Feature/FunctionalComponentTest/generated_code_with_data_set__dataset__component_with_rules_blade_php______tests_Feature_resources_view___de_php__.snap
+++ b/tests/.pest/snapshots/Feature/FunctionalComponentTest/generated_code_with_data_set__dataset__component_with_rules_blade_php______tests_Feature_resources_view___de_php__.snap
@@ -1,0 +1,40 @@
+<?php
+
+use Livewire\Volt\Actions;
+use Livewire\Volt\CompileContext;
+use Livewire\Volt\Contracts\Compiled;
+use Livewire\Volt\Component;
+
+new class extends Component implements Livewire\Volt\Contracts\FunctionalComponent
+{
+    public static CompileContext $__context;
+
+    use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+
+    public $title;
+
+    public function mount()
+    {
+        (new Actions\InitializeState)->execute(static::$__context, $this, get_defined_vars());
+
+        (new Actions\CallHook('mount'))->execute(static::$__context, $this, get_defined_vars());
+    }
+
+    public function save()
+    {
+        $arguments = [static::$__context, $this, func_get_args()];
+
+        return (new Actions\CallMethod('save'))->execute(...$arguments);
+    }
+
+    protected function rules()
+    {
+        return (new Actions\ReturnRules)->execute(static::$__context, $this, []);
+    }
+
+    protected function messages()
+    {
+        return (new Actions\ReturnValidationMessages)->execute(static::$__context, $this, []);
+    }
+
+};

--- a/tests/Feature/CompilerContext/RulesTest.php
+++ b/tests/Feature/CompilerContext/RulesTest.php
@@ -32,6 +32,14 @@ it('may be defined using named arguments', function () {
     ]);
 });
 
+it('may be defined using closures', function () {
+    $context = CompileContext::instance();
+
+    rules(fn () => ['name' => 'required|min:6', 'email' => 'nullable|email']);
+
+    expect($context->rules)->resolve()->toBe(['name' => 'required|min:6', 'email' => 'nullable|email']);
+});
+
 test('precedence', function () {
     $context = CompileContext::instance();
 
@@ -41,5 +49,11 @@ test('precedence', function () {
     expect($context->rules)->toBe([
         'name' => 'second',
         'email' => 'first',
+    ]);
+
+    rules(fn () => ['name' => 'third']);
+
+    expect($context->rules)->resolve()->toBe([
+        'name' => 'third',
     ]);
 });

--- a/tests/Feature/FunctionalComponentTest.php
+++ b/tests/Feature/FunctionalComponentTest.php
@@ -246,6 +246,19 @@ it('can have dynamic properties', function () {
     ]);
 });
 
+it('can have rules', function () {
+    $component = Livewire::test('component-with-rules');
+
+    $component->assertSet('saved', false)
+        ->call('save')
+        ->assertSee('The title field is missing.')
+        ->assertSet('saved', false)
+        ->updateProperty('title', 'Hello')
+        ->call('save')
+        ->assertDontSee('The title field is missing.')
+        ->assertSet('saved', true);
+});
+
 it('can have reactive state', function () {
     $component = Livewire::test('component-with-reactive-state.todos');
 

--- a/tests/Feature/resources/views/functional-api/component-with-rules.blade.php
+++ b/tests/Feature/resources/views/functional-api/component-with-rules.blade.php
@@ -1,0 +1,25 @@
+<?php
+
+use function Livewire\Volt\{state, rules};
+
+state(['title' => '']);
+
+rules(fn () => ['title' => ['required', 'min:5']])
+    ->messages(['title' => 'The title field is missing.']);
+
+$save = function () {
+    $this->validate();
+
+    $this->saved = true;
+}; ?>
+
+<div>
+    <form wire:submit="save">
+        <input type="text" wire:model="title">
+        @error('title') <span class="error">{{ $message }}</span> @enderror
+
+        <button type="submit">Save</button>
+    </form>
+</div>
+
+


### PR DESCRIPTION
Fixes: https://github.com/livewire/volt/pull/67.
Test suite failing because of: https://github.com/livewire/volt/pull/70.

This pull request fixes an issue with the `rules` function where is not possible to defer the rules resolution like so:

```php
rules(fn () => [
    'name' => ['required', 'min:6'],
    'email' => ['required', 'email', 'not_in:'.Auth::user()->email]
]);
```