### PR TITLE
Replaced classic Livewire views path from `views.livewire` to `config…

### DIFF
--- a/src/Console/MakeCommand.php
+++ b/src/Console/MakeCommand.php
@@ -46,7 +46,7 @@ class MakeCommand extends GeneratorCommand
     {
         $paths = Volt::paths();
 
-        $mountPath = isset($paths[0]) ? $paths[0]->path : resource_path('views/livewire');
+        $mountPath = isset($paths[0]) ? $paths[0]->path : resource_path(config('livewire.view_path'));
 
         return $mountPath.'/'.Str::lower(Str::finish($this->argument('name'), '.blade.php'));
     }


### PR DESCRIPTION
Replaced classic Livewire views path from `views.livewire` to `config('livewire.view_path')`.