### PR TITLE
Replaced classic Livewire path from `views/livewire` to `config('live…

### DIFF
--- a/tests/Feature/Console/MakeCommandTest.php
+++ b/tests/Feature/Console/MakeCommandTest.php
@@ -9,7 +9,7 @@ beforeEach(function () {
 it('makes components', function (string $name, string $viewPath, string $testPath) {
     $this->artisan('make:volt', ['name' => $name])->assertOk();
 
-    $viewPath = resource_path('views/livewire/'.$viewPath);
+    $viewPath = resource_path(config('livewire.view_path').'/'.$viewPath);
     $testPath = base_path('tests/Feature/Livewire'.$testPath);
 
     expect($viewPath)->toBeFile()
@@ -113,7 +113,7 @@ it('makes components with pest tests', function (string $name, string $alias, st
 
 afterEach(function () {
     collect([
-        resource_path('views/livewire'),
+        resource_path(config('livewire.view_path')),
         base_path('tests/Feature/Livewire'),
     ])->each(function (string $path) {
         if (File::exists($path)) {


### PR DESCRIPTION
Replaced classic Livewire path from `views/livewire` to `config('livewire.view_path')`.