### PR TITLE
fix: State properties

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -26,7 +26,13 @@ function state(mixed ...$properties): StateOptions
             if (is_string($properties[0])) {
                 $properties = [$properties[0] => null];
             } elseif (Arr::isAssoc($properties[0])) {
-                $properties = $properties[0];
+                $properties = array_map(
+                    static fn($key, $value) => is_numeric($key) ? [$value => null] : [$key => $value],
+                    array_keys($properties[0]),
+                    $properties[0]
+                );
+
+                $properties = array_merge(...$properties);
             } else {
                 $properties = array_fill_keys($properties[0], null);
             }

--- a/tests/.pest/snapshots/Feature/FunctionalComponentTest/generated_code_with_data_set__dataset__component_state_with_without_keys_blade_php______tests_Feature_resources_view___de_php__.snap
+++ b/tests/.pest/snapshots/Feature/FunctionalComponentTest/generated_code_with_data_set__dataset__component_state_with_without_keys_blade_php______tests_Feature_resources_view___de_php__.snap
@@ -1,0 +1,25 @@
+<?php
+
+use Livewire\Volt\Actions;
+use Livewire\Volt\CompileContext;
+use Livewire\Volt\Contracts\Compiled;
+use Livewire\Volt\Component;
+
+new class extends Component implements Livewire\Volt\Contracts\FunctionalComponent
+{
+    public static CompileContext $__context;
+
+    use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+
+    public $without;
+
+    public $with;
+
+    public function mount()
+    {
+        (new Actions\InitializeState)->execute(static::$__context, $this, get_defined_vars());
+
+        (new Actions\CallHook('mount'))->execute(static::$__context, $this, get_defined_vars());
+    }
+
+};

--- a/tests/Feature/FunctionalComponentTest.php
+++ b/tests/Feature/FunctionalComponentTest.php
@@ -281,6 +281,13 @@ it('can listen events', function () {
         ->assertSee('Events received: 2.');
 });
 
+it('can have state with and without array keys', function () {
+    $component = Livewire::test('component-state-with-without-keys');
+
+    $component->assertSet('without', null);
+    $component->assertSet('with', 'value');
+});
+
 it('can have url state', function () {
     $component = Livewire::test('component-with-url-state');
 

--- a/tests/Feature/resources/views/functional-api/component-state-with-without-keys.blade.php
+++ b/tests/Feature/resources/views/functional-api/component-state-with-without-keys.blade.php
@@ -1,0 +1,11 @@
+<?php
+
+use function Livewire\Volt\{state};
+
+state(['without', 'with' => 'value'])
+
+?>
+
+<div>
+
+</div>


### PR DESCRIPTION
Hi there! I found a bug. If the states contain an element without a key and an element with a key, an error will occur and a component with a numeric property will be generated. my pr fixes this case

Example:

```php
state(['article', 'count' => 0]);
```

I'll get an error

`syntax error, unexpected token "$", expecting variable`

Generated component

```php
new class extends Component implements Livewire\Volt\Contracts\FunctionalComponent
{
    public static CompileContext $__context;

    use Illuminate\Foundation\Auth\Access\AuthorizesRequests;

    public $0;

    public $count;
```

`public $0;`