### PR TITLE
[1.x] Allow setting title using a closure in functional API

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -96,7 +96,7 @@ function layout(string $layout): void
 /**
  * Define the component's title.
  */
-function title(string $title): void
+function title(Closure|string $title): void
 {
     CompileContext::instance()->title = $title;
 }

--- a/src/Actions/ReturnTitle.php
+++ b/src/Actions/ReturnTitle.php
@@ -2,6 +2,8 @@
 
 namespace Livewire\Volt\Actions;
 
+use Closure;
+use Illuminate\Container\Container;
 use Livewire\Volt\CompileContext;
 use Livewire\Volt\Component;
 use Livewire\Volt\Contracts\Action;
@@ -13,6 +15,12 @@ class ReturnTitle implements Action
      */
     public function execute(CompileContext $context, Component $component, array $arguments): ?string
     {
+        if ($context->title instanceof Closure) {
+            return Container::getInstance()->call(
+                Closure::bind($context->title, $component, $component::class),
+            );
+        }
+
         return $context->title;
     }
 }

--- a/src/CompileContext.php
+++ b/src/CompileContext.php
@@ -20,7 +20,7 @@ class CompileContext
         public array $variables,
         public array $state,
         public ?string $layout,
-        public ?string $title,
+        public Closure|string|null $title,
         public ?Closure $listeners,
         public array $inlineListeners,
         public Closure|array $rules,

--- a/tests/Feature/Actions/ReturnTitleTest.php
+++ b/tests/Feature/Actions/ReturnTitleTest.php
@@ -17,3 +17,32 @@ it('returns the title view', function () {
 
     expect($result)->toBe('my title');
 });
+
+it('returns a static title using a closure', function () {
+    $context = CompileContext::make();
+
+    $context->title = fn () => 'my title from a closure';
+
+    $component = new class extends Component
+    {
+    };
+
+    $result = (new ReturnTitle)->execute($context, $component, []);
+
+    expect($result)->toBe('my title from a closure');
+});
+
+it('returns a computed title using a closure', function () {
+    $context = CompileContext::make();
+
+    $context->title = fn () => "welcome back $this->username";
+
+    $component = new class extends Component
+    {
+        public string $username = 'Tom';
+    };
+
+    $result = (new ReturnTitle)->execute($context, $component, []);
+
+    expect($result)->toBe('welcome back Tom');
+});

--- a/tests/Feature/CompilerContext/TitleTest.php
+++ b/tests/Feature/CompilerContext/TitleTest.php
@@ -17,3 +17,15 @@ it('may be defined', function () {
 
     expect($context->title)->toBe('my custom title');
 });
+
+it('may be set using closures', function () {
+    $context = CompileContext::instance();
+
+    title(fn () => 'my custom title from a closure');
+
+    expect($context->title)
+        ->toBeCallable()
+        ->and($context->title)
+        ->resolve()
+        ->toBe('my custom title from a closure');
+});


### PR DESCRIPTION
This PR adds the ability to set titles using closures when using the functional API.

As of 1.5.0 it's not possible to make "computed" titles using the functional API. To achieve this, the class-based API has to be used using the `rendering` lifecycle hook as described [in the Volt documentation](https://livewire.laravel.com/docs/volt#modifying-the-view-instance).

By allowing closures to be passed to the `title` function it will allow developers to defined titles like so:

```php
state(['firstName' => 'Tom']);

title(fn () => 'This is the title');

// Or even

title(fn () => "Hi $this->firstName");
```

I will submit a separate PR for documentation.