### PR TITLE
[1.x] Fixes non-usage of `livewire.view_path` configuration

### DIFF
--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -83,7 +83,7 @@ class InstallCommand extends Command
      */
     protected function ensureLivewireDirectoryExists(): void
     {
-        if (! is_dir($directory = resource_path('views/livewire'))) {
+        if (! is_dir($directory = config('livewire.view_path', resource_path('views/livewire')))) {
             File::ensureDirectoryExists($directory);
 
             File::put($directory.'/.gitkeep', '');

--- a/src/Console/MakeCommand.php
+++ b/src/Console/MakeCommand.php
@@ -46,7 +46,7 @@ class MakeCommand extends GeneratorCommand
     {
         $paths = Volt::paths();
 
-        $mountPath = isset($paths[0]) ? $paths[0]->path : resource_path('views/livewire');
+        $mountPath = isset($paths[0]) ? $paths[0]->path : config('livewire.view_path', resource_path('views/livewire'));
 
         return $mountPath.'/'.Str::lower(Str::finish($this->argument('name'), '.blade.php'));
     }

--- a/stubs/VoltServiceProvider.stub
+++ b/stubs/VoltServiceProvider.stub
@@ -21,7 +21,7 @@ class VoltServiceProvider extends ServiceProvider
     public function boot(): void
     {
         Volt::mount([
-            resource_path('views/livewire'),
+            config('livewire.view_path', resource_path('views/livewire')),
             resource_path('views/pages'),
         ]);
     }


### PR DESCRIPTION
This pull request replaces https://github.com/livewire/volt/pull/76, and it fixes the non-usage of `livewire.view_path` configuration.