### PR TITLE
Use paths from object property, not local variable

### DIFF
--- a/src/MountedDirectories.php
+++ b/src/MountedDirectories.php
@@ -29,7 +29,7 @@ class MountedDirectories
 
         $this->paths = array_merge($this->paths, $paths->all());
 
-        View::replaceNamespace('volt-livewire', $paths->pluck('path')->all());
+        View::replaceNamespace('volt-livewire', collect($this->paths)->pluck('path')->all());
     }
 
     /**


### PR DESCRIPTION
Volt is already doing the work to save multiple component paths, we just need to use those saved paths when setting up the namespace.

This provides support for easily adding paths to components in custom packages like:

```php
use Illuminate\Support\ServiceProvider;
use Livewire\Volt\Volt;

class PackageServiceProvider extends ServiceProvider
{
    /**
     * Bootstrap the application services.
     */
    public function boot()
    {
        $this->app->booted( function() {
            Volt::mount( __DIR__.'/../resources/views/livewire' );
        } );
    }
}
```

Fixes #87 and #92 and #94