### PR TITLE
Ensure Mounted Directories are unique

### DIFF
--- a/src/MountedDirectories.php
+++ b/src/MountedDirectories.php
@@ -28,7 +28,7 @@ class MountedDirectories
             ->values()
             ->map(fn (string $path) => new MountedDirectory($path, Arr::wrap($uses)))
             ->filter(fn (MountedDirectory $newMountedDirectory) => ! collect($this->paths)
-                ->contains(fn (MountedDirectory $mountedDirectory) => $mountedDirectory->path === $newMountedDirectory->path && $mountedDirectory->uses === $mountedDirectory->uses));
+                ->contains(fn (MountedDirectory $mountedDirectory) => $mountedDirectory->path === $newMountedDirectory->path && $mountedDirectory->uses === $newMountedDirectory->uses));
 
         $this->paths = array_merge($this->paths, $paths->all());
 

--- a/src/MountedDirectories.php
+++ b/src/MountedDirectories.php
@@ -22,10 +22,13 @@ class MountedDirectories
      */
     public function mount(array|string $paths, array|string $uses = []): void
     {
+    
         $paths = collect(Arr::wrap($paths))
             ->filter(fn (string $path) => is_dir($path))
             ->values()
-            ->map(fn (string $path) => new MountedDirectory($path, Arr::wrap($uses)));
+            ->map(fn (string $path) => new MountedDirectory($path, Arr::wrap($uses)))
+            ->filter(fn (MountedDirectory $newMountedDirectory) => ! collect($this->paths)
+                ->contains(fn (MountedDirectory $mountedDirectory) => $mountedDirectory->path === $newMountedDirectory->path && $mountedDirectory->uses === $mountedDirectory->uses));
 
         $this->paths = array_merge($this->paths, $paths->all());
 

--- a/tests/Unit/VoltTest.php
+++ b/tests/Unit/VoltTest.php
@@ -8,3 +8,22 @@ it('resolves an manager instance', function () {
 
     expect($instance)->toBeInstanceOf(VoltManager::class);
 });
+
+it('will not store duplicate paths', function () {
+    /** @var VoltManager $managerInstance */
+    $managerInstance = Volt::getFacadeRoot();
+
+    expect(count($managerInstance->paths()))->toBe(0);
+
+    $managerInstance->mount([
+        $path1 = __DIR__ . '/resources/views/livewire',
+    ]);
+
+    $managerInstance->mount([
+        $path1
+    ]);
+
+    $managerInstance->mount($path1);
+
+    expect(count($managerInstance->paths()))->toBe(1);
+});


### PR DESCRIPTION
This PR filters mounted directories to ensure there isn't already a `MountedDirectory` with the exact same properties.

closes #96 
