### PR TITLE
ensure mounted directories are unique

### DIFF
--- a/src/MountedDirectories.php
+++ b/src/MountedDirectories.php
@@ -22,10 +22,13 @@ class MountedDirectories
      */
     public function mount(array|string $paths, array|string $uses = []): void
     {
+    
         $paths = collect(Arr::wrap($paths))
             ->filter(fn (string $path) => is_dir($path))
             ->values()
-            ->map(fn (string $path) => new MountedDirectory($path, Arr::wrap($uses)));
+            ->map(fn (string $path) => new MountedDirectory($path, Arr::wrap($uses)))
+            ->filter(fn (MountedDirectory $newMountedDirectory) => ! collect($this->paths)
+                ->contains(fn (MountedDirectory $mountedDirectory) => $mountedDirectory->path === $newMountedDirectory->path && $mountedDirectory->uses === $newMountedDirectory->uses));
 
         $this->paths = array_merge($this->paths, $paths->all());
 

--- a/tests/Unit/VoltTest.php
+++ b/tests/Unit/VoltTest.php
@@ -8,3 +8,22 @@ it('resolves an manager instance', function () {
 
     expect($instance)->toBeInstanceOf(VoltManager::class);
 });
+
+it('will not store duplicate paths', function () {
+    /** @var VoltManager $managerInstance */
+    $managerInstance = Volt::getFacadeRoot();
+
+    expect(count($managerInstance->paths()))->toBe(0);
+
+    $managerInstance->mount([
+        $path1 = __DIR__ . '/resources/views/livewire',
+    ]);
+
+    $managerInstance->mount([
+        $path1
+    ]);
+
+    $managerInstance->mount($path1);
+
+    expect(count($managerInstance->paths()))->toBe(1);
+});


### PR DESCRIPTION
 This PR filters the given `$paths, $uses` in `MountedDirectories::mount()` to ensure there isn't already a `MountedDirectory` with the exact same properties.

This won't break anything since it doesn't change any functionality. The same views as before will still be mounted, we just won't add a duplicate `MountedDirectory` instance for them to the `$paths` array if one already exists.

closes #96 

EDIT (more context):

One might expect that mounting the same directory more than once with volt wouldn't change anything, and it doesn't. However there is an unfortunate and unexpected side effect: each call will increase memory usage by adding a new `MountedDirectory` instance to the manager's footprint with the same properties as the previous one, and for no useful reason as far as I can tell. 

Of course it looks like the $paths property isn't even being used anyway: the local $paths variable created directly from the given`$path, $uses` is being used instead to create the views using only the given parameters and ignoring the existing properties. But that is a separate issue and this pr just aims to decrease unwanted/unneeded memory usage regardless of the variable or scope used for view creation.

It may be also worth looking at whether the views should be created from the given `$paths, $uses`, or all of the paths in the `paths` property as proposed in #95. 

A few of us have been looking into how to use `livewire/volt` in a package and provide components to a laravel application. One of the ways we've found to do this is by calling `Volt::mount()` from a package's service provider. In order to prevent overwriting paths already mounted by the application, we've found that we can merge in the existing paths.

However in doing so I've noticed that whether existing paths are merged in or not, Volt stores all the paths from all the calls to `mount()` regardless of whether or not they are being used. This includes duplicates, which serve no discernible purpose. 

https://github.com/livewire/volt/issues/94
https://github.com/livewire/volt/issues/92
https://github.com/livewire/volt/issues/87