### PR TITLE
Add stub option to make command

### DIFF
--- a/src/Console/MakeCommand.php
+++ b/src/Console/MakeCommand.php
@@ -16,6 +16,7 @@ use Symfony\Component\Console\Input\InputOption;
 class MakeCommand extends GeneratorCommand
 {
     use CreatesMatchingTest;
+    use GetStubOption;
 
     /**
      * The name and signature of the console command.

--- a/src/Console/MakeCommand.php
+++ b/src/Console/MakeCommand.php
@@ -3,6 +3,7 @@
 namespace Livewire\Volt\Console;
 
 use Illuminate\Console\Concerns\CreatesMatchingTest;
+use Illuminate\Console\Concerns\GetStubOption;
 use Illuminate\Console\GeneratorCommand;
 use Illuminate\Foundation\Application;
 use Illuminate\Support\Facades\File;

--- a/src/Console/MakeCommand.php
+++ b/src/Console/MakeCommand.php
@@ -174,6 +174,7 @@ class MakeCommand extends GeneratorCommand
         return [
             ['class', null, InputOption::VALUE_NONE, 'Create a class based component'],
             ['force', 'f', InputOption::VALUE_NONE, 'Create the Volt component even if the component already exists'],
+            ['stub', 's', InputOption::VALUE_OPTIONAL, 'The stub file to use'],
         ];
     }
 


### PR DESCRIPTION
Depends on https://github.com/laravel/framework/pull/50709

## Usage:

### Supports passing either the name of a stub, or full path to a stub as an option

```bash
php artisan make:volt "todos/create" --stub="volt-create-form"
```
Will find and use `base_path('stubs/volt-create-form.stub')` if it exists.

```bash
php artisan make:volt "todos/create" \
  --stub="/home/taylor/stubs/volt/forms/create-form.stub"
```
will find and use `/home/taylor/stubs/volt/forms/create-form.stub` if it exists.

If it cannot find a stub under the name or path, it will ignore the option altogether and behave as it always has.