### PR TITLE
Remove final from render

### DIFF
--- a/src/Component.php
+++ b/src/Component.php
@@ -36,7 +36,7 @@ abstract class Component extends LivewireComponent
     /**
      * Render the component.
      */
-    final public function render(): mixed
+    public function render(): mixed
     {
         $alias = $this->getAlias();
 

--- a/src/ComponentFactory.php
+++ b/src/ComponentFactory.php
@@ -70,7 +70,7 @@ class ComponentFactory
 
             $__path = $path;
 
-            CompileContext::instance()->variables = (static function () use ($__path) {
+            $variables = (static function () use ($__path) {
                 require $__path;
 
                 return array_map(function (mixed $variable) {
@@ -79,9 +79,11 @@ class ComponentFactory
                         : $variable;
                 }, get_defined_vars());
             })();
+            CompileContext::instance()->variables =  array_merge(CompileContext::instance()->variables, $variables);
         } finally {
             ob_get_clean();
         }
+
     }
 
     /**

--- a/src/ComponentFactory.php
+++ b/src/ComponentFactory.php
@@ -79,11 +79,11 @@ class ComponentFactory
                         : $variable;
                 }, get_defined_vars());
             })();
+
             CompileContext::instance()->variables =  array_merge(CompileContext::instance()->variables, $variables);
         } finally {
             ob_get_clean();
         }
-
     }
 
     /**

--- a/src/VoltServiceProvider.php
+++ b/src/VoltServiceProvider.php
@@ -116,7 +116,7 @@ class VoltServiceProvider extends ServiceProvider
                 $component = FragmentMap::get($component);
             }
 
-            return $this->assertSeeLivewire($component); // @phpstan-ignore-line
+            return $this->assertSeeLivewire($component);
         });
 
         TestResponse::macro('assertDontSeeVolt', function ($component) {
@@ -126,7 +126,7 @@ class VoltServiceProvider extends ServiceProvider
                 $component = FragmentMap::get($component);
             }
 
-            return $this->assertDontSeeLivewire($component); // @phpstan-ignore-line
+            return $this->assertDontSeeLivewire($component);
         });
     }
 }


### PR DESCRIPTION
Can we please remove final from the render method? 

I'm playing with adding support for rendering react/vue components inside of volt components with https://github.com/ijpatricio/mingle, but naturally it needs to be able to hijack the render method to function.

I can't think of any reasons why removing the final keyword would be a breaking change here.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
