### PR TITLE
Make class component if project uses Volt Class components

### DIFF
--- a/src/Console/MakeCommand.php
+++ b/src/Console/MakeCommand.php
@@ -60,7 +60,7 @@ class MakeCommand extends GeneratorCommand
             $stubName = 'volt-component-class.stub';
         } elseif ($this->option('functional')) {
             $stubName = 'volt-component.stub';
-        } elseif ($this->usingClass()) {
+        } elseif ($this->alreadyUsingClasses()) {
             $stubName = 'volt-component-class.stub';
         } else {
             $stubName = 'volt-component.stub';
@@ -72,14 +72,17 @@ class MakeCommand extends GeneratorCommand
     }
 
     /**
-     * Determine if the project is using class-based components.
+     * Determine if the project is currently using class-based components.
      *
      * @return bool
      */
-    protected function usingClass(): bool
+    protected function alreadyUsingClasses(): bool
     {
         $paths = Volt::paths();
-        $mountPath = isset($paths[0]) ? $paths[0]->path : config('livewire.view_path', resource_path('views/livewire'));
+
+        $mountPath = isset($paths[0])
+            ? $paths[0]->path
+            : config('livewire.view_path', resource_path('views/livewire'));
 
         $files = collect(File::allFiles($mountPath));
 

--- a/src/Console/MakeCommand.php
+++ b/src/Console/MakeCommand.php
@@ -56,14 +56,15 @@ class MakeCommand extends GeneratorCommand
      */
     protected function getStub(): string
     {
-        $stubName = $this->option('class')
-            ? 'volt-component-class.stub'
-            : ($this->option('functional')
-                ? 'volt-component.stub'
-            : ($this->usingClass()
-                ? 'volt-component-class.stub'
-                : 'volt-component.stub'
-         ));
+        if ($this->option('class')) {
+            $stubName = 'volt-component-class.stub';
+        } elseif ($this->option('functional')) {
+            $stubName = 'volt-component.stub';
+        } elseif ($this->usingClass()) {
+            $stubName = 'volt-component-class.stub';
+        } else {
+            $stubName = 'volt-component.stub';
+        }
 
         return file_exists($customPath = $this->laravel->basePath('stubs/'.$stubName))
             ? $customPath


### PR DESCRIPTION
I appreciate the check that `make:test` provides when you are using a starter kit or already have a Pest or a PHPUnit test created in the project, and I think it makes a great addition to Volt, as well.

I always forget to add the `--class` option when creating a new Volt component for my projects.

This adds a `usingClass` function to check to see if any Livewire Volt components already exist in the `Volt::paths()` and if that is identified as a Class component, then it will default to using the Class component stub when the `volt:make` command is run.

Additionally, I did add a `--functional` option to the command due to the fact that there are some folks who might want Class & Functional components to exist in the same project. While that can be written manually, I figured it wouldn't hurt to have an additional option, just in case.