### PR TITLE
Trigger hook on parent array property

### DIFF
--- a/src/Actions/CallPropertyHook.php
+++ b/src/Actions/CallPropertyHook.php
@@ -21,6 +21,11 @@ class CallPropertyHook implements Action
      */
     public function execute(CompileContext $context, Component $component, array $arguments): mixed
     {
+        if (! isset($context->{$this->hookName}[$this->propertyName]) && str_contains($this->propertyName, '.')) {
+            [$this->propertyName, $additionalArgument] = explode('.', $this->propertyName, 2);
+            $arguments = array_merge([$additionalArgument], $arguments);
+        }
+
         $hook = $context->{$this->hookName}[$this->propertyName] ?? fn () => null;
 
         return call_user_func_array(

--- a/tests/Feature/Actions/CallPropertyHookTest.php
+++ b/tests/Feature/Actions/CallPropertyHookTest.php
@@ -17,3 +17,17 @@ it('calls property hooks on the component', function () {
 
     expect($result)->toBe('bar');
 });
+
+it('calls array property hooks on the component', function () {
+    $context = CompileContext::make();
+
+    $context->updating = ['foo' => fn ($prop) => $prop];
+
+    $component = new class extends Component
+    {
+    };
+
+    $result = (new CallPropertyHook('updating', 'foo.bar'))->execute($context, $component, []);
+
+    expect($result)->toBe('bar');
+});


### PR DESCRIPTION
This PR addresses issue https://github.com/livewire/volt/issues/107.

It allows triggering the update hook on the parent array property when a change is made to a key.

**Before :**
When updating on a key, the hook is only triggered for that key.

```php
updated([
    'profiles' => function () {
        // Not triggered
    },
    /*'profiles.0' => function () {
        // You need to explicitly listen for the key being updated.
        // There can be several keys.
        // You must listen to them all if you want to take action on any changes made to the parent array.
    }*/
]);
```

**With this PR :**
When updating on a key, the hook is triggered on the parent array, if not explicitly listening for changes to the key.

```php
updated([
    'profiles' => function ($key) {
        // Triggered, and the modified key is passed as a parameter.
    }
]);
```

That said... I'm wondering whether we should make it more dynamic to handle deep subkey as well.

```php
updated([
    'profiles.admin' => function () {
        // Triggered on change made to key 'profiles.admin.0'.
    }
]);
```

This PR will forward the hook to the parent property `profiles` not to `profiles.admin`.