### PR TITLE
Passing data to layout of a Volt full page component

### DIFF
--- a/src/Component.php
+++ b/src/Component.php
@@ -57,7 +57,7 @@ abstract class Component extends LivewireComponent
             : Facades\View::make('volt-livewire::'.$alias, $data);
 
         if ($layout) {
-            $view->layout($layout);
+            $view->layout($layout, $data);
         }
 
         if ($title) {


### PR DESCRIPTION
This pull request enable sharing data passed using `with` helper with the layout component as well.

This is to solve the issue https://github.com/livewire/volt/issues/121.