### PR TITLE
Bump Livewire minimum version to include fix from livewire/livewire#9216

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "require": {
         "php": "^8.1",
         "laravel/framework": "^10.38.2|^11.0|^12.0",
-        "livewire/livewire": "^3.0"
+        "livewire/livewire": "^3.6.1"
     },
     "require-dev": {
         "laravel/folio": "^1.1",


### PR DESCRIPTION
This PR bumps the minimum Livewire version to v3.6.1 which includes the fix for Volt from PR livewire/livewire#9216