### PR TITLE
Add missing session method to state options and related tests

### DIFF
--- a/src/Options/StateOptions.php
+++ b/src/Options/StateOptions.php
@@ -5,6 +5,7 @@ namespace Livewire\Volt\Options;
 use Livewire\Attributes\Locked;
 use Livewire\Attributes\Modelable;
 use Livewire\Attributes\Reactive;
+use Livewire\Attributes\Session;
 use Livewire\Attributes\Url;
 use Livewire\Volt\Property;
 
@@ -65,6 +66,14 @@ class StateOptions
     public function reactive(): static
     {
         return $this->attribute(Reactive::class);
+    }
+
+    /**
+     * Indicate the state should be tracked in the session.
+     */
+    public function session(?string $key = null): static
+    {
+        return $this->attribute(Session::class, key: $key);
     }
 
     /**

--- a/tests/Feature/ClassComponentTest.php
+++ b/tests/Feature/ClassComponentTest.php
@@ -21,6 +21,40 @@ it('can be rendered', function () {
         ->assertSee('Hello World');
 });
 
+it('can have session state', function () {
+    $component = Livewire::test('component-with-session-attribute');
+
+    $component->assertSet('tab', 'livewire');
+
+    $component->assertSeeHtmlInOrder([
+        '<li>Livewire 3</li>',
+        '<li>Laravel Volt</li>',
+        '<li>Flux UI</li>',
+    ]);
+
+    $component->set('tab', 'react');
+
+    $component->assertSeeHtmlInOrder([
+        '<li>React 19</li>',
+        '<li>Typescript</li>',
+        '<li>Inertia 2</li>',
+        '<li>shadcdn/ui</li>',
+    ]);
+
+    $component->set('tab', 'vue');
+
+    $component->assertSeeHtmlInOrder($tags = [
+        '<li>Vue 3</li>',
+        '<li>Typescript</li>',
+        '<li>Inertia 2</li>',
+        '<li>shadcdn-vue</li>',
+    ]);
+
+    $component->refresh();
+
+    $component->assertSeeHtmlInOrder($tags);
+});
+
 it('can have url attribute', function () {
     $component = Livewire::test('component-with-url-attribute');
 

--- a/tests/Feature/Compiler/SessionTest.php
+++ b/tests/Feature/Compiler/SessionTest.php
@@ -1,0 +1,29 @@
+<?php
+
+use Livewire\Volt\CompileContext;
+use Livewire\Volt\Compiler;
+
+use function Livewire\Volt\state;
+
+it('may not be defined', function () {
+    $code = Compiler::contextToString(CompileContext::instance());
+
+    expect($code)->not->toContain('#[\Livewire\Attributes\Session()]');
+});
+
+it('may be defined', function () {
+    state('tabOne')->session();
+    state('tabTwo')->session(key: 'tab');
+
+    $code = Compiler::contextToString(CompileContext::instance());
+
+    expect($code)->toContain(
+        <<<'PHP'
+        #[\Livewire\Attributes\Session()]
+        public $tabOne;
+
+        #[\Livewire\Attributes\Session(key: 'tab')]
+        public $tabTwo;
+    PHP
+    );
+});

--- a/tests/Feature/CompilerContext/SessionTest.php
+++ b/tests/Feature/CompilerContext/SessionTest.php
@@ -1,0 +1,28 @@
+<?php
+
+use Livewire\Attributes\Session;
+use Livewire\Volt\CompileContext;
+use Pest\Expectation;
+
+use function Livewire\Volt\state;
+
+it('may be defined', function () {
+    $context = CompileContext::instance();
+
+    state('name');
+    state(tabOne: 1)->session();
+    state(tabTwo: 2)->session(key: 'tab');
+
+    expect($context->state)->toHaveKeys(['name', 'tabOne', 'tabTwo'])
+        ->sequence(
+            fn (Expectation $property) => $property->attributes->toBe([]),
+            fn (Expectation $property) => $property->attributes->toBe([
+                Session::class => [],
+            ]),
+            fn (Expectation $property) => $property->attributes->toBe([
+                Session::class => [
+                    'key' => 'tab',
+                ],
+            ]),
+        );
+});

--- a/tests/Feature/FunctionalComponentTest.php
+++ b/tests/Feature/FunctionalComponentTest.php
@@ -288,6 +288,40 @@ it('can have state with and without array keys', function () {
     $component->assertSet('with', 'value');
 });
 
+it('can have session state', function () {
+    $component = Livewire::test('component-with-session-state');
+
+    $component->assertSet('tab', 'livewire');
+
+    $component->assertSeeHtmlInOrder([
+        '<li>Livewire 3</li>',
+        '<li>Laravel Volt</li>',
+        '<li>Flux UI</li>',
+    ]);
+
+    $component->set('tab', 'react');
+
+    $component->assertSeeHtmlInOrder([
+        '<li>React 19</li>',
+        '<li>Typescript</li>',
+        '<li>Inertia 2</li>',
+        '<li>shadcdn/ui</li>',
+    ]);
+
+    $component->set('tab', 'vue');
+
+    $component->assertSeeHtmlInOrder($tags = [
+        '<li>Vue 3</li>',
+        '<li>Typescript</li>',
+        '<li>Inertia 2</li>',
+        '<li>shadcdn-vue</li>',
+    ]);
+
+    $component->refresh();
+
+    $component->assertSeeHtmlInOrder($tags);
+});
+
 it('can have url state', function () {
     $component = Livewire::test('component-with-url-state');
 

--- a/tests/Feature/resources/views/class-api/component-with-session-attribute.blade.php
+++ b/tests/Feature/resources/views/class-api/component-with-session-attribute.blade.php
@@ -1,0 +1,54 @@
+<?php
+
+use Livewire\Attributes\Computed;
+use Livewire\Attributes\Session;
+use Livewire\Volt\Component;
+
+new class extends Component
+{
+    #[Session]
+    public $tab = 'livewire';
+
+    #[Computed]
+    public function tags()
+    {
+        return collect([
+        'react' => [
+            'React 19',
+            'Typescript',
+            'Inertia 2',
+            'shadcdn/ui',
+        ],
+        'vue' => [
+            'Vue 3',
+            'Typescript',
+            'Inertia 2',
+            'shadcdn-vue',
+        ],
+        'livewire' => [
+            'Livewire 3',
+            'Laravel Volt',
+            'Flux UI',
+        ],
+    ][$this->tab] ?? []);
+    }
+}; ?>
+
+<div>
+    <h1>Choose your Starter Kit:</h1>
+
+    <input wire:model="tab" type="radio" id="react" name="tab" value="react">
+    <label for="react">React</label>
+
+    <input wire:model="tab" type="radio" id="vue" name="tab" value="vue">
+    <label for="vue">Vue</label>
+
+    <input wire:model="tab" type="radio" id="livewire" name="tab" value="livewire">
+    <label for="livewire">Livewire</label>
+
+    <ul>
+        @foreach($this->tags as $tag)
+            <li>{{ $tag }}</li>
+        @endforeach
+    </ul>
+</div>

--- a/tests/Feature/resources/views/functional-api/component-with-session-state.blade.php
+++ b/tests/Feature/resources/views/functional-api/component-with-session-state.blade.php
@@ -1,0 +1,49 @@
+<?php
+
+use function Livewire\Volt\computed;
+use function Livewire\Volt\state;
+
+state(tab: 'livewire')->session();
+
+$tags = computed(function () {
+    return collect([
+        'react' => [
+            'React 19',
+            'Typescript',
+            'Inertia 2',
+            'shadcdn/ui',
+        ],
+        'vue' => [
+            'Vue 3',
+            'Typescript',
+            'Inertia 2',
+            'shadcdn-vue',
+        ],
+        'livewire' => [
+            'Livewire 3',
+            'Laravel Volt',
+            'Flux UI',
+        ],
+    ][$this->tab] ?? []);
+});
+
+?>
+
+<div>
+    <h1>Choose your Starter Kit:</h1>
+
+    <input wire:model="tab" type="radio" id="react" name="tab" value="react">
+    <label for="react">React</label>
+
+    <input wire:model="tab" type="radio" id="vue" name="tab" value="vue">
+    <label for="vue">Vue</label>
+
+    <input wire:model="tab" type="radio" id="livewire" name="tab" value="livewire">
+    <label for="livewire">Livewire</label>
+
+    <ul>
+        @foreach($this->tags as $tag)
+            <li>{{ $tag }}</li>
+        @endforeach
+    </ul>
+</div>


### PR DESCRIPTION
This PR allows using the `Session` attribute in functional API components.

Old way:
```php
state('tab')->attribute(\Livewire\Attributes\Session::class, key: 'tab')
```

New way:
```php
state('tab')->session(key: 'tab')
```

Notes:
- I added a minimum of tests where I deemed necessary by mimicking the ones testing the `Url` attributes.
- I believe a "default" argument would be awesome to add so I will make a PR to the Livewire repo before continuing here.