### PR TITLE
Support the dot in the make:volt command

### DIFF
--- a/src/Console/MakeCommand.php
+++ b/src/Console/MakeCommand.php
@@ -50,10 +50,10 @@ class MakeCommand extends GeneratorCommand
 
         $argumentName = $this->argument('name');
 
-        if (!str_contains($argumentName, '.blade.php')) {
+        if (! str_contains($argumentName, '.blade.php')) {
             $view = str_replace('.', '/', $argumentName);
         } else {
-           $view = $argumentName;
+            $view = $argumentName;
         }
 
         return $mountPath.'/'.Str::lower(Str::finish($view, '.blade.php'));
@@ -194,7 +194,7 @@ class MakeCommand extends GeneratorCommand
     {
         $argumentName = $this->argument('name');
 
-        if (!str_contains($argumentName, '.blade.php')) {
+        if (! str_contains($argumentName, '.blade.php')) {
             $processedName = str_replace('.', '/', $argumentName);
         } else {
             $processedName = $argumentName;

--- a/src/Console/MakeCommand.php
+++ b/src/Console/MakeCommand.php
@@ -48,7 +48,9 @@ class MakeCommand extends GeneratorCommand
 
         $mountPath = isset($paths[0]) ? $paths[0]->path : config('livewire.view_path', resource_path('views/livewire'));
 
-        return $mountPath.'/'.Str::lower(Str::finish($this->argument('name'), '.blade.php'));
+        $view = str_replace('.', '/', $this->argument('name'));
+
+        return $mountPath.'/'.Str::lower(Str::finish($view, '.blade.php'));
     }
 
     /**
@@ -184,7 +186,7 @@ class MakeCommand extends GeneratorCommand
      */
     protected function fullyQualifiedTestName(): string
     {
-        $name = Str::of(Str::lower($this->argument('name')))->replace('.blade.php', '');
+        $name = Str::of(Str::lower(str_replace('.', '/', $this->argument('name'))))->replace('.blade.php', '');
 
         $namespacedName = Str::of(
             Str::of($name)

--- a/src/Console/MakeCommand.php
+++ b/src/Console/MakeCommand.php
@@ -48,7 +48,13 @@ class MakeCommand extends GeneratorCommand
 
         $mountPath = isset($paths[0]) ? $paths[0]->path : config('livewire.view_path', resource_path('views/livewire'));
 
-        $view = str_replace('.', '/', $this->argument('name'));
+        $argumentName = $this->argument('name');
+
+        if (!str_contains($argumentName, '.blade.php')) {
+            $view = str_replace('.', '/', $argumentName);
+        } else {
+           $view = $argumentName;
+        }
 
         return $mountPath.'/'.Str::lower(Str::finish($view, '.blade.php'));
     }
@@ -186,7 +192,15 @@ class MakeCommand extends GeneratorCommand
      */
     protected function fullyQualifiedTestName(): string
     {
-        $name = Str::of(Str::lower(str_replace('.', '/', $this->argument('name'))))->replace('.blade.php', '');
+        $argumentName = $this->argument('name');
+
+        if (!str_contains($argumentName, '.blade.php')) {
+            $processedName = str_replace('.', '/', $argumentName);
+        } else {
+            $processedName = $argumentName;
+        }
+       
+        $name = Str::of(Str::lower($processedName))->replace('.blade.php', '');
 
         $namespacedName = Str::of(
             Str::of($name)

--- a/tests/Feature/Console/MakeCommandTest.php
+++ b/tests/Feature/Console/MakeCommandTest.php
@@ -33,6 +33,7 @@ it('makes components', function (string $name, string $viewPath, string $testPat
 })->with([
     ['index', 'index.blade.php', 'IndexTest.php'],
     ['chirps/index', 'chirps/index.blade.php', 'Chirps/IndexTest.php'],
+    ['chirps.index', 'chirps/index.blade.php', 'Chirps/IndexTest.php'],
     ['chirps-index.blade.php', 'chirps-index.blade.php', 'ChirpsIndexTest.php'],
     ['chirps_index.blade.php', 'chirps_index.blade.php', 'ChirpsIndexTest.php'],
     ['chirps/index.blade.php', 'chirps/index.blade.php', 'Chirps/IndexTest.php'],
@@ -73,6 +74,7 @@ it('makes components with phpunit tests', function (string $name, string $alias,
 })->with([
     ['index', 'index', 'index.blade.php', '', 'IndexTest', 'IndexTest.php'],
     ['chirps/index', 'chirps.index', 'chirps/index.blade.php', '\Chirps', 'IndexTest', 'Chirps/IndexTest.php'],
+    ['chirps.index', 'chirps.index', 'chirps/index.blade.php', '\Chirps', 'IndexTest', 'Chirps/IndexTest.php'],
     ['chirps_index.blade.php', 'chirps_index', 'chirps_index.blade.php', '', 'ChirpsIndexTest', 'ChirpsIndexTest.php'],
     ['chirps-index.blade.php', 'chirps-index', 'chirps-index.blade.php', '', 'ChirpsIndexTest', 'ChirpsIndexTest.php'],
     ['chirps/index.blade.php', 'chirps.index', 'chirps/index.blade.php', '\Chirps', 'IndexTest', 'Chirps/IndexTest.php'],
@@ -106,6 +108,7 @@ it('makes components with pest tests', function (string $name, string $alias, st
 })->with([
     ['index', 'index', 'index.blade.php', '', 'IndexTest', 'IndexTest.php'],
     ['chirps/index', 'chirps.index', 'chirps/index.blade.php', '\Chirps', 'IndexTest', 'Chirps/IndexTest.php'],
+    ['chirps.index', 'chirps.index', 'chirps/index.blade.php', '\Chirps', 'IndexTest', 'Chirps/IndexTest.php'],
     ['chirps_index.blade.php', 'chirps_index', 'chirps_index.blade.php', '', 'ChirpsIndexTest', 'ChirpsIndexTest.php'],
     ['chirps-index.blade.php', 'chirps-index', 'chirps-index.blade.php', '', 'ChirpsIndexTest', 'ChirpsIndexTest.php'],
     ['chirps/index.blade.php', 'chirps.index', 'chirps/index.blade.php', '\Chirps', 'IndexTest', 'Chirps/IndexTest.php'],


### PR DESCRIPTION
Hi,

looking over Caleb Porzio's Livewire screencasts today, I noticed that the `make:volt`command doesn't support the dot notation, that is already present in `make:livewire` command.

Here's an example of both outputs:

```bash
# Using the regular slash notation

php artisan make:volt component/index

INFO  Volt component [resources/views/livewire/component/index.blade.php] created successfully.  

```

```bash
# Using the dot notation with the current setup
# This fails to create component/index, but rather creates component.index.blade.php

php artisan make:volt component.index

INFO  Volt component [resources/views/livewire/component.index.blade.php] created successfully.  

```

```bash
# Using the dot notation in make:livewire

php artisan make:livewire component.index

 COMPONENT CREATED  🤙

CLASS: app/Livewire/Component/Index.php
VIEW:  resources/views/livewire/component/index.blade.php 

```

I thought this would be a nice alignment to the way things operate. I tried to make the changes as minimal as possible and updated the tests as well.

Hope this does the trick and gets merged, but even if it doesn't I would love to see it supported.

Kind regards,
g