### PR TITLE
Fix multiple scripts test to use a single root element

### DIFF
--- a/tests/Feature/resources/views/functional-api/component-with-multiple-scripts.blade.php
+++ b/tests/Feature/resources/views/functional-api/component-with-multiple-scripts.blade.php
@@ -4,12 +4,10 @@
 
 <div>
     Hello {{ $first }}
-</div>
 
-<?php state('first'); ?>
+    <?php state('first'); ?>
 
-<div>
     Hello {{ $second }}
-</div>
 
-<?php state(['second' => 'Otwell']); ?>
+    <?php state(['second' => 'Otwell']); ?>
+</div>


### PR DESCRIPTION
Livewire enforces that each component contain a single root element.

This test is failing locally because it produces two sibling elements.

I changed to a single root element and the test now passes.