### PR TITLE
Remove redundant "When to Apply" section from skill body

### DIFF
--- a/resources/boost/skills/volt-development/SKILL.blade.php
+++ b/resources/boost/skills/volt-development/SKILL.blade.php
@@ -10,14 +10,6 @@ metadata:
 @endphp
 # Volt Development
 
-## When to Apply
-
-Activate this skill when:
-
-- Creating Volt single-file components
-- Converting traditional Livewire components to Volt
-- Testing Volt components
-
 ## Documentation
 
 Use `search-docs` for detailed Volt patterns and documentation.


### PR DESCRIPTION
## Summary

- Removes the `## When to Apply` section from the Volt skill file
- This section was already fully covered by the skill's `description` frontmatter — removing it doesn't affect skill triggering behavior

See laravel/boost#669 for the corresponding change in the Boost monorepo.