### PR TITLE
Fix Blaze compatibility

### DIFF
--- a/src/Precompilers/ExtractFragments.php
+++ b/src/Precompilers/ExtractFragments.php
@@ -132,6 +132,7 @@ class ExtractFragments
             '__livewire' => null,
             '__path' => null,
             '__split' => null,
+            '__blaze' => null,
             '_instance' => null,
             'app' => null,
             'component' => null,


### PR DESCRIPTION
When using the `@volt` directive in a project with Blaze installed, Livewire will throw a `CorruptComponentPayloadException` on every component update. This happens because of the `get_defined_vars()` call generated by the directive which captures the `$__blaze` variable that holds the entire Blaze runtime and appends it to the component data.

This type of issue is already handled in Volt by excluding auto-injected variables like `$__env` or `$__livewire` from the component data. This PR simply adds `$__blaze` to that exclusion list.

Fixes https://github.com/livewire/blaze/issues/187